### PR TITLE
citations: iterative, grounded, deduplicating [CITE] resolution (#19)

### DIFF
--- a/ai/citation_resolver.py
+++ b/ai/citation_resolver.py
@@ -68,9 +68,10 @@ async def generate_search_queries(
     ])
 
     loop = asyncio.get_event_loop()
-    response = await loop.run_in_executor(None, partial(chat, client,
-        "You are a scientific literature search expert for microbial ecology.",
-        f"""For each citation placeholder below, generate a PubMed search query
+    try:
+        response = await loop.run_in_executor(None, partial(chat, client,
+            "You are a scientific literature search expert for microbial ecology.",
+            f"""For each citation placeholder below, generate a PubMed search query
 that would find the most relevant reference paper.
 
 {context_text}
@@ -80,8 +81,12 @@ Each query should be a focused PubMed search string (2-6 key terms).
 Example: ["metagenome-assembled genome quality CheckM", "nanopore long-read metagenomics review"]
 
 Return ONLY the JSON array.""",
-        model=model, max_tokens=1000, temperature=0.3,
-    ))
+            model=model, max_tokens=1000, temperature=0.3,
+        ))
+    except Exception as e:
+        # No LLM reachable — degrade to keyword extraction so resolution still runs
+        log.warning(f"Query generation LLM call failed, using fallback: {e}")
+        return [_fallback_query(c) for c in contexts]
 
     try:
         text = response.strip()
@@ -166,3 +171,189 @@ def _surname(name: str) -> str:
         return parts[0]
     # Otherwise surname is last part
     return parts[-1]
+
+
+async def refine_query(
+    context: dict,
+    previous_query: str,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> str | None:
+    """Reformulate a PubMed query that returned no results.
+
+    Returns a new, broader query string, or None to stop refining (either the
+    model declined or no LLM is reachable). Used to give each citation slot a
+    second chance before falling back to a bare placeholder.
+    """
+    client = get_client(base_url=base_url, api_key=api_key)
+    loop = asyncio.get_event_loop()
+    try:
+        response = await loop.run_in_executor(None, partial(chat, client,
+            "You are a scientific literature search expert. Broaden or correct failed PubMed queries.",
+            f"""This PubMed query returned no results:
+
+    "{previous_query}"
+
+It was meant to find a reference for this claim:
+"{context.get('sentence', '')}"
+Hint: {context.get('hint') or 'none'}
+
+Suggest ONE broader or corrected PubMed query (2-5 key terms).
+Return ONLY the query string — no quotes, no explanation.
+If you cannot meaningfully improve it, return the single word STOP.""",
+            model=model, max_tokens=40, temperature=0.3,
+        ))
+    except Exception as e:
+        log.warning(f"Query refinement LLM call failed: {e}")
+        return None
+
+    q = (response or "").strip().strip('"').strip()
+    if not q or q.upper().startswith("STOP") or q.lower() == previous_query.lower():
+        return None
+    return q
+
+
+async def select_citation(
+    context: dict,
+    candidates: list[dict],
+    already_cited: list[str] | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> dict | None:
+    """Pick the best-fitting candidate article for a citation slot.
+
+    Returns the chosen article dict, or None if no candidate genuinely supports
+    the claim (better to leave a placeholder than cite the wrong paper — this is
+    the anti-fabrication early-stop). With a single candidate, or when no LLM is
+    reachable, degrades to the top-ranked result without an extra LLM call.
+    """
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    client = get_client(base_url=base_url, api_key=api_key)
+    listing = "\n".join(
+        f"{i}. {c.get('title', '')} — "
+        f"{', '.join(c.get('authors', [])[:3])} ({c.get('year', '')}) "
+        f"{c.get('journal', '')}"
+        for i, c in enumerate(candidates)
+    )
+    already = "; ".join(t for t in (already_cited or []) if t) or "none"
+    loop = asyncio.get_event_loop()
+    try:
+        response = await loop.run_in_executor(None, partial(chat, client,
+            "You are a scientific literature expert selecting the single most relevant "
+            "citation. Never force a citation that does not genuinely support the claim.",
+            f"""A manuscript needs a citation for this claim:
+
+"{context.get('sentence', '')}"
+Hint: {context.get('hint') or 'none'}
+
+Candidate papers from PubMed:
+{listing}
+
+Already cited elsewhere (prefer reusing one of these if it fits equally well): {already}
+
+Reply with ONLY the number of the single best-fitting candidate, or the word
+NONE if none of them genuinely support this specific claim.""",
+            model=model, max_tokens=10, temperature=0.0,
+        ))
+    except Exception as e:
+        log.warning(f"Citation selection LLM call failed, using top result: {e}")
+        return candidates[0]
+
+    text = (response or "").strip().upper()
+    if text.startswith("NONE"):
+        return None
+    match = re.search(r"\d+", text)
+    if match:
+        idx = int(match.group())
+        if 0 <= idx < len(candidates):
+            return candidates[idx]
+    return candidates[0]
+
+
+class CitationLibrary:
+    """Accumulates cited articles, deduplicating by DOI / PMID / title.
+
+    Guarantees the same paper is never added twice (even if two [CITE] slots
+    resolve to it) and that cite keys are unique and stable across the run.
+    Only articles passed to :meth:`add` — i.e. real search results — ever enter
+    the bibliography.
+    """
+
+    def __init__(self):
+        self._by_id: dict[str, str] = {}          # dedup id -> cite_key
+        self._entries: dict[str, tuple[dict, str]] = {}  # cite_key -> (article, bibtex)
+        self._order: list[str] = []               # cite_key insertion order
+
+    @staticmethod
+    def _dedup_ids(article: dict) -> list[str]:
+        """All identifiers this article can be matched on.
+
+        Indexing under every available id (not just a single preferred one)
+        makes dedup robust to inconsistent PubMed metadata — e.g. the same
+        paper returned once with a DOI and once with only a PMID.
+        """
+        ids = []
+        doi = (article.get("doi") or "").strip().lower()
+        if doi:
+            ids.append(f"doi:{doi}")
+        pmid = (article.get("pmid") or "").strip()
+        if pmid:
+            ids.append(f"pmid:{pmid}")
+        if not ids:
+            title = re.sub(r"[^a-z0-9]", "", (article.get("title") or "").lower())
+            if title:
+                ids.append(f"title:{title}")
+        return ids
+
+    def _make_key(self, article: dict) -> str:
+        authors = article.get("authors", [])
+        first = re.sub(r"[^a-z0-9]", "", _surname(authors[0]).lower()) if authors else ""
+        first = first or "unknown"
+        year = re.sub(r"[^0-9]", "", article.get("year", "")) or "nd"
+        title_word = "ref"
+        for w in (article.get("title", "") or "").split():
+            wclean = re.sub(r"[^a-z0-9]", "", w.lower())
+            if len(wclean) > 2:
+                title_word = wclean
+                break
+        base = f"{first}{year}{title_word}"
+        key, suffix = base, ord("b")
+        while key in self._entries:
+            key = f"{base}{chr(suffix)}"
+            suffix += 1
+        return key
+
+    def add(self, article: dict) -> str:
+        """Add an article (or return the existing key if already cited)."""
+        ids = self._dedup_ids(article)
+        for did in ids:
+            if did in self._by_id:
+                key = self._by_id[did]
+                # register any identifiers this occurrence adds
+                for other in ids:
+                    self._by_id.setdefault(other, key)
+                return key
+        key = self._make_key(article)
+        for did in ids:
+            self._by_id[did] = key
+        self._entries[key] = (article, format_bibtex_entry(article, key))
+        self._order.append(key)
+        return key
+
+    def article_for(self, key: str) -> dict:
+        return self._entries[key][0]
+
+    def titles(self) -> list[str]:
+        return [article.get("title", "") for article, _ in self._entries.values()]
+
+    def bibtex(self) -> str:
+        return "\n\n".join(self._entries[k][1] for k in self._order)
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/ai/manuscript_generator.py
+++ b/ai/manuscript_generator.py
@@ -344,6 +344,26 @@ def _format_interview(interview_data: dict) -> str:
     return "\n".join(formatted)
 
 
+def _make_searcher(search_fn, candidates_per_query: int):
+    """Wrap a search callable so it always returns a list, awaiting coroutines.
+
+    Passes the candidate count only when the callable accepts it, so both the
+    real ``search_pubmed(query, max_results)`` and 1-arg test mocks work.
+    """
+    try:
+        accepts_count = len(inspect.signature(search_fn).parameters) >= 2
+    except (TypeError, ValueError):
+        accepts_count = False
+
+    async def run(query):
+        result = search_fn(query, candidates_per_query) if accepts_count else search_fn(query)
+        if inspect.isawaitable(result):
+            result = await result
+        return result or []
+
+    return run
+
+
 async def resolve_citations(
     sections: dict,
     pipeline_type: str = "",
@@ -351,16 +371,27 @@ async def resolve_citations(
     base_url: str | None = None,
     api_key: str | None = None,
     model: str | None = None,
+    max_query_rounds: int = 2,
+    candidates_per_query: int = 5,
 ) -> tuple[dict, str]:
     """Resolve [CITE] placeholders in manuscript sections.
 
-    For each [CITE], generates a PubMed search query, searches PubMed,
-    and replaces the placeholder with an inline citation. Returns the
-    updated sections and a BibTeX bibliography string.
+    For each [CITE] slot this runs a small grounded loop (adapted from
+    AI-Scientist's citation harness): search PubMed, and if nothing comes back
+    reformulate the query and try again up to ``max_query_rounds``, stopping as
+    soon as candidates are found. When several candidates return, the model
+    selects the best fit (or declines, leaving a placeholder rather than citing
+    the wrong paper). All chosen articles flow through a
+    :class:`CitationLibrary` that deduplicates by DOI/PMID/title, so the same
+    paper is never added twice and only real search results enter the
+    bibliography. Returns the updated sections and a BibTeX bibliography string.
 
-    search_fn: optional callable(query) -> list[dict] for testing/mocking.
-               Each dict should have title, authors, journal, year, doi, pmid.
+    search_fn: optional callable(query[, max_results]) -> list[dict] for
+               testing/mocking. Each dict should have title, authors, journal,
+               year, doi, pmid.
     """
+    from .citation_resolver import CitationLibrary, refine_query, select_citation, _fallback_query
+
     # Combine all sections into one text for context extraction
     full_text = "\n\n".join(
         f"## {name}\n{content}" for name, content in sections.items()
@@ -370,7 +401,7 @@ async def resolve_citations(
     if not contexts:
         return sections, ""
 
-    # Generate search queries from contexts
+    # Generate an initial search query per placeholder
     queries = await generate_search_queries(
         contexts,
         pipeline_type=pipeline_type,
@@ -379,43 +410,48 @@ async def resolve_citations(
         model=model,
     )
 
-    # Search PubMed for each query and collect results
-    bibtex_entries = []
+    search = _make_searcher(search_fn, candidates_per_query) if search_fn else None
+    library = CitationLibrary()
     replacements = []  # (original_text, replacement_text)
 
-    for i, (ctx, query) in enumerate(zip(contexts, queries)):
-        article = None
-        if search_fn:
-            try:
-                result = search_fn(query)
-                if inspect.isawaitable(result):
-                    result = await result
-                results = result
-                if results:
-                    article = results[0]
-            except Exception as e:
-                log.warning(f"Search failed for query '{query}': {e}")
-            # Rate limit between searches
-            await asyncio.sleep(0.5)
+    for i, ctx in enumerate(contexts):
+        # queries only covers the first batch of contexts; fall back for the rest
+        query = queries[i] if i < len(queries) and queries[i] else _fallback_query(ctx)
 
-        if article:
-            # Generate citation key: firstauthor2023keyword
-            authors = article.get("authors", [])
-            from .citation_resolver import _surname
-            first_author = _surname(authors[0]).lower() if authors else "unknown"
-            year = article.get("year", "")
-            title_word = article.get("title", "").split()[0].lower() if article.get("title") else "ref"
-            cite_key = f"{first_author}{year}{title_word}"
+        candidates = []
+        if search:
+            for round_idx in range(max_query_rounds):
+                try:
+                    candidates = await search(query)
+                except Exception as e:
+                    log.warning(f"Search failed for query '{query}': {e}")
+                    candidates = []
+                await asyncio.sleep(0.5)  # NCBI rate limit
+                if candidates:
+                    break  # early stop for this slot — we found matches
+                if round_idx < max_query_rounds - 1:
+                    new_query = await refine_query(
+                        ctx, query, base_url=base_url, api_key=api_key, model=model
+                    )
+                    if not new_query:
+                        break  # model declined to broaden — give up on this slot
+                    query = new_query
 
-            inline = format_inline_citation(article, cite_key)
-            bibtex = format_bibtex_entry(article, cite_key)
-            bibtex_entries.append(bibtex)
-        else:
-            # No search result — leave a numbered placeholder
-            cite_key = f"ref{i+1}"
+        inline = None
+        if candidates:
+            chosen = await select_citation(
+                ctx, candidates, already_cited=library.titles(),
+                base_url=base_url, api_key=api_key, model=model,
+            )
+            if chosen:
+                cite_key = library.add(chosen)
+                inline = format_inline_citation(library.article_for(cite_key), cite_key)
+
+        if inline is None:
+            # No result, or the model declined to cite — leave a readable placeholder
             hint = ctx.get("hint", "")
-            inline = f"[{hint or cite_key}]"
-            log.info(f"No PubMed result for citation {i+1}: '{query}'")
+            inline = f"[{hint or f'ref{i+1}'}]"
+            log.info(f"No citation resolved for placeholder {i+1}: '{query}'")
 
         original = full_text[ctx["span"][0]:ctx["span"][1]]
         replacements.append((original, inline))
@@ -437,5 +473,4 @@ async def resolve_citations(
         else:
             updated_sections[name] = sections[name]
 
-    bibliography = "\n\n".join(bibtex_entries)
-    return updated_sections, bibliography
+    return updated_sections, library.bibtex()

--- a/tests/test_citation_library.py
+++ b/tests/test_citation_library.py
@@ -1,0 +1,144 @@
+"""Tests for the iterative, deduplicating citation resolution (issue #19).
+
+These are deterministic and need neither a live LLM nor network access: the
+mock search callables stand in for PubMed, and the LLM-dependent steps
+(query generation / refinement / selection) are pointed at a fast-fail address
+so they degrade gracefully to their non-LLM fallbacks.
+"""
+import sys
+import pytest
+
+sys.path.insert(0, "/data/omc/omc-platform")
+
+# Fast-fail LLM endpoint: nothing listens here, so LLM calls raise immediately
+# and the resolver falls back to its deterministic paths.
+NO_LLM = "http://127.0.0.1:9/v1"
+
+
+def _article(title, author, year, doi, pmid):
+    return {
+        "title": title, "authors": [author], "year": year,
+        "journal": "J", "volume": "1", "pages": "1-2", "doi": doi, "pmid": pmid,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CitationLibrary — deduplication + stable, unique keys
+# ---------------------------------------------------------------------------
+
+def test_library_dedupes_same_paper():
+    from ai.citation_resolver import CitationLibrary
+    lib = CitationLibrary()
+    art = _article("CheckM2 genome quality", "Chklovski A", "2023", "10.1/x", "111")
+    k1 = lib.add(art)
+    k2 = lib.add(dict(art))            # identical DOI → same entry
+    k3 = lib.add({**art, "doi": ""})   # DOI dropped but same PMID → still same
+    assert k1 == k2 == k3
+    assert len(lib) == 1
+    assert lib.bibtex().count("@article{") == 1
+
+
+def test_library_distinct_papers_get_distinct_keys():
+    from ai.citation_resolver import CitationLibrary
+    lib = CitationLibrary()
+    k1 = lib.add(_article("GTDB-Tk taxonomy", "Chaumeil P", "2019", "10.2/y", "222"))
+    k2 = lib.add(_article("CheckM2 quality", "Chklovski A", "2023", "10.1/x", "111"))
+    assert k1 != k2
+    assert len(lib) == 2
+    assert lib.bibtex().count("@article{") == 2
+
+
+def test_library_key_collision_is_disambiguated():
+    """Two different papers that would generate the same base key stay unique."""
+    from ai.citation_resolver import CitationLibrary
+    lib = CitationLibrary()
+    a = _article("Genome analysis methods", "Smith J", "2020", "10/a", "1")
+    b = _article("Genome analysis tools", "Smith J", "2020", "10/b", "2")
+    ka, kb = lib.add(a), lib.add(b)     # both base to smith2020genome
+    assert ka != kb
+    assert len(lib) == 2
+
+
+# ---------------------------------------------------------------------------
+# select_citation — single-candidate and empty degrade without an LLM
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_select_single_candidate_needs_no_llm():
+    from ai.citation_resolver import select_citation
+    cand = [_article("X", "A B", "2020", "10/z", "9")]
+    chosen = await select_citation({"sentence": "s"}, cand, base_url=NO_LLM)
+    assert chosen is cand[0]
+
+
+@pytest.mark.asyncio
+async def test_select_no_candidates_returns_none():
+    from ai.citation_resolver import select_citation
+    assert await select_citation({"sentence": "s"}, [], base_url=NO_LLM) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_citations — dedup across slots, early stop, bounded rounds
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dedup_across_slots():
+    """Three [CITE] slots that all resolve to the same paper yield one entry."""
+    from ai.manuscript_generator import resolve_citations
+    sections = {"introduction": "First claim [CITE]. Second [CITE]. Third [CITE]."}
+
+    async def mock(query, n=5):
+        return [_article("One Paper", "Smith J", "2023", "10.1/same", "999")]
+
+    updated, bib = await resolve_citations(sections, search_fn=mock, base_url=NO_LLM)
+    assert "[CITE" not in " ".join(updated.values())
+    assert bib.count("@article{") == 1          # deduped to a single reference
+    assert "(Smith, 2023)" in updated["introduction"]
+
+
+@pytest.mark.asyncio
+async def test_search_stops_on_first_hit():
+    """A slot that gets a hit on round 1 does not trigger further search rounds."""
+    from ai.manuscript_generator import resolve_citations
+    calls = {"n": 0}
+
+    async def mock(query, n=5):
+        calls["n"] += 1
+        return [_article("P", "Ada B", "2021", "10/z", "7")]
+
+    await resolve_citations({"m": "x [CITE]."}, search_fn=mock,
+                            max_query_rounds=3, base_url=NO_LLM)
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_results_are_bounded_and_leave_placeholder():
+    """With no LLM to refine a failed query, the loop stops after one round and
+    leaves a readable placeholder rather than fabricating a citation."""
+    from ai.manuscript_generator import resolve_citations
+    calls = {"n": 0}
+
+    async def mock(query, n=5):
+        calls["n"] += 1
+        return []
+
+    updated, bib = await resolve_citations(
+        {"m": "some claim [CITE: some hint]."},
+        search_fn=mock, max_query_rounds=3, base_url=NO_LLM,
+    )
+    assert calls["n"] == 1                       # refine declined (no LLM) → bounded
+    assert bib == ""                             # nothing fabricated
+    assert "[some hint]" in updated["m"]
+
+
+@pytest.mark.asyncio
+async def test_no_search_fn_leaves_placeholders():
+    """Anti-fabrication: without a search backend, nothing enters the bibliography."""
+    from ai.manuscript_generator import resolve_citations
+    updated, bib = await resolve_citations(
+        {"m": "claim one [CITE]. claim two [CITE: mag quality]."},
+        search_fn=None, base_url=NO_LLM,
+    )
+    assert bib == ""
+    assert "[ref1]" in updated["m"]
+    assert "[mag quality]" in updated["m"]


### PR DESCRIPTION
## Summary

Reworks `[CITE]` resolution from a single blind pass into the round-based, grounded loop from our AI-harness plan (issue #19), adapted from AI-Scientist's citation harness while keeping **PubMed** as the backend.

## What changed

- **Iterative per-slot rounds** — search PubMed; on an empty result the model reformulates the query and retries (`max_query_rounds`, default 2), stopping early the moment candidates appear.
- **Grounded selection** — when multiple candidates return, the model picks the best fit for the specific claim, or replies `NONE` and leaves a placeholder rather than citing the wrong paper. Single-candidate / no-LLM paths skip the extra call.
- **`CitationLibrary`** — dedupes by DOI/PMID/title (indexed under *every* identifier so inconsistent metadata still collapses), unique stable cite keys, and only real API-returned articles ever enter the bibliography.
- **Graceful degradation** — every LLM touchpoint falls back to a deterministic path when no model is reachable.

Two latent bugs fixed along the way: citations past the 15th were dropped by `zip()` truncation; dedup missed a paper returned once with a DOI and once PMID-only.

## Tests

New `tests/test_citation_library.py` — 9 deterministic tests (no LLM/network): dedup, key-collision disambiguation, early-stop, bounded rounds, anti-fabrication. All 12 citation tests pass (9 new + 3 existing preserved).

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
