### PR TITLE
reviews: close the review→revise loop with grounded checks (#20)

### DIFF
--- a/ai/manuscript_checks.py
+++ b/ai/manuscript_checks.py
@@ -1,0 +1,179 @@
+"""Deterministic manuscript checks (issue #20).
+
+Machine-verifiable problems that ground the revise loop — no LLM required.
+These are OMC's analog of AI-Scientist's chktex / figure-reference checks:
+instead of "make it better", the revise pass is handed concrete, checkable
+defects (leftover placeholders, figure references that don't line up, precise
+numbers absent from the pipeline data, missing/short required sections).
+
+Each check returns a list of issue dicts shaped like a review comment so the
+revise pass can consume review findings and check findings uniformly:
+
+    {"section", "issue", "detail", "severity", "confidence", "source"}
+"""
+import json
+import re
+
+REQUIRED_SECTIONS = ["abstract", "introduction", "methods", "results", "discussion"]
+
+# Explicit placeholder tokens the draft prompt is known to emit when it lacks
+# information. Kept to a known list to avoid flagging legitimate bracketed text.
+_PLACEHOLDER_RE = re.compile(
+    r"\[(?:CITE(?::[^\]]*)?|AUTHOR:[^\]]*|CITATION NEEDED|TODO[^\]]*|PLACEHOLDER[^\]]*|X)\]",
+    re.IGNORECASE,
+)
+
+# "Figure 3", "Fig. 2", "Figures 1 and 2"
+_FIGURE_REF_RE = re.compile(r"\b[Ff]ig(?:ure|\.)?\s*(\d+)")
+
+# Decimals and percentages — the number forms most dangerous to hallucinate.
+# Plain small integers and 4-digit years are deliberately excluded (too noisy).
+# A trailing % is kept in the reported token so findings read naturally.
+_PRECISE_NUMBER_RE = re.compile(r"\d+\.\d+\s*%?|\d+\s*%")
+
+
+def _issue(section, issue, detail, severity):
+    return {
+        "section": section,
+        "issue": issue,
+        "detail": detail,
+        "severity": severity,
+        "confidence": 1.0,
+        "source": "check",
+    }
+
+
+def check_placeholders(sections: dict) -> list[dict]:
+    """Flag leftover [CITE] / [AUTHOR:] / [CITATION NEEDED] / [TODO] placeholders."""
+    issues = []
+    for name, content in sections.items():
+        seen = set()
+        for m in _PLACEHOLDER_RE.finditer(content or ""):
+            token = m.group(0)
+            if token.lower() in seen:
+                continue
+            seen.add(token.lower())
+            # A leftover [CITE] is expected to happen occasionally (unresolved
+            # reference); [AUTHOR:]/[TODO]/[X] mean the draft is incomplete.
+            is_cite = token.upper().startswith("[CITE")
+            issues.append(_issue(
+                name, "unresolved-placeholder",
+                f"The placeholder `{token}` is still present in the {name} section. "
+                f"Resolve it (supply the citation/value) or, if the information is "
+                f"unavailable, convert it to an explicit [AUTHOR: ...] note.",
+                "major" if is_cite else "critical",
+            ))
+    return issues
+
+
+def check_figure_references(sections: dict, available_figures=None) -> list[dict]:
+    """Cross-check numbered figure references against available figures.
+
+    available_figures: iterable of figure identifiers actually generated from
+    the pipeline data (e.g. keys of the figures JSON). When provided, flags
+    references to figures that don't exist and figures that are never
+    referenced — mirroring AI-Scientist's unused/invalid figure detection.
+    """
+    figures = list(available_figures or [])
+    n_available = len(figures)
+
+    referenced = set()
+    for content in sections.values():
+        for m in _FIGURE_REF_RE.finditer(content or ""):
+            referenced.add(int(m.group(1)))
+
+    issues = []
+    if n_available:
+        over = sorted(n for n in referenced if n > n_available)
+        if over:
+            issues.append(_issue(
+                "general", "figure-reference-mismatch",
+                f"The text references Figure(s) {over} but only {n_available} "
+                f"figure(s) were generated from the pipeline data. Renumber the "
+                f"references or remove those that have no corresponding figure.",
+                "major",
+            ))
+        if not referenced:
+            issues.append(_issue(
+                "results", "unused-figures",
+                f"{n_available} figure(s) were generated from the pipeline data "
+                f"but none are referenced in the text. Reference the relevant "
+                f"figures in Results, or drop the unused ones.",
+                "minor",
+            ))
+    return issues
+
+
+def _flatten_number_haystack(results_data) -> str:
+    """A string containing every number present in the pipeline results."""
+    if not results_data:
+        return ""
+    return json.dumps(results_data, default=str)
+
+
+def check_numbers_supported(sections: dict, results_data=None) -> list[dict]:
+    """Flag precise numbers in Abstract/Results not found in the pipeline data.
+
+    Only decimals and percentages are checked (the forms most damaging to
+    fabricate); years and small integers are ignored to limit false positives.
+    Findings are advisory — the revise pass verifies each against the data.
+    """
+    haystack = _flatten_number_haystack(results_data)
+    if not haystack:
+        return []
+
+    issues = []
+    for name in ("abstract", "results"):
+        content = sections.get(name) or ""
+        unsupported = []
+        seen = set()
+        for m in _PRECISE_NUMBER_RE.finditer(content):
+            digits = re.sub(r"[^\d.]", "", m.group(0))
+            if not digits or digits in seen:
+                continue
+            seen.add(digits)
+            if digits not in haystack:
+                unsupported.append(m.group(0).strip())
+            if len(unsupported) >= 10:
+                break
+        if unsupported:
+            issues.append(_issue(
+                name, "unsupported-numbers",
+                f"These numbers in the {name} section were not found in the "
+                f"pipeline results data and may be unsupported: {unsupported}. "
+                f"Verify each against the data; correct or remove any that cannot "
+                f"be traced to a pipeline output.",
+                "major",
+            ))
+    return issues
+
+
+def check_required_sections(sections: dict) -> list[dict]:
+    """Flag required sections that are missing or suspiciously short."""
+    issues = []
+    for name in REQUIRED_SECTIONS:
+        content = (sections.get(name) or "").strip()
+        if not content:
+            issues.append(_issue(
+                name, "missing-section",
+                f"The required {name.title()} section is missing or empty.",
+                "critical",
+            ))
+        elif len(content) < 100:
+            issues.append(_issue(
+                name, "thin-section",
+                f"The {name.title()} section is only {len(content)} characters — "
+                f"too short to be complete. Expand it with the relevant content.",
+                "major",
+            ))
+    return issues
+
+
+def run_all_checks(sections: dict, results_data=None, available_figures=None) -> list[dict]:
+    """Run every deterministic check and return the combined issue list."""
+    return [
+        *check_required_sections(sections),
+        *check_placeholders(sections),
+        *check_figure_references(sections, available_figures),
+        *check_numbers_supported(sections, results_data),
+    ]

--- a/ai/manuscript_generator.py
+++ b/ai/manuscript_generator.py
@@ -474,3 +474,151 @@ async def resolve_citations(
             updated_sections[name] = sections[name]
 
     return updated_sections, library.bibtex()
+
+
+# ---------------------------------------------------------------------------
+# Revise loop (issue #20) — feed review findings + deterministic checks back
+# into a grounded section rewrite, the OMC analog of AI-Scientist's reflection.
+# ---------------------------------------------------------------------------
+
+REVISE_INSTRUCTIONS = SYSTEM_PROMPT + """
+
+You are now REVISING a single section to address specific reviewer and
+automated-check findings. Rules:
+- Fix only what the findings call out. Preserve all other content, facts, and numbers.
+- Never invent data, citations, numbers, software versions, or study details to
+  satisfy a finding. If a finding asks for information you do not have, insert a
+  clear [AUTHOR: ...] note instead of guessing.
+- Keep unresolved literature references as bare [CITE] placeholders.
+- Do not delete content merely to satisfy a length or completeness note — add the
+  missing content or mark it [AUTHOR: ...].
+
+Return ONLY the revised section text — no preamble, no code fences.
+If no change is warranted, return exactly: NO CHANGES NEEDED
+"""
+
+
+def flatten_review_comments(reviews) -> list[dict]:
+    """Flatten run_all_reviews() output into a flat issue list for revision."""
+    issues = []
+    for review in reviews or []:
+        rtype = review.get("review_type", "review")
+        for c in review.get("comments", []) or []:
+            issues.append({
+                "section": (c.get("section") or "general").lower(),
+                "issue": c.get("issue", ""),
+                "detail": c.get("detail", ""),
+                "severity": c.get("severity", "suggestion"),
+                "confidence": c.get("confidence", 0.5),
+                "source": rtype,
+            })
+    return issues
+
+
+def _strip_code_fences(text: str) -> str:
+    t = text.strip()
+    if t.startswith("```"):
+        t = re.sub(r"^```[a-zA-Z]*\n", "", t)
+        if t.endswith("```"):
+            t = t[:-3]
+    return t.strip()
+
+
+def _build_revise_prompt(section, text, issues, general_issues, study_metadata=None):
+    lines = [f"Section: {section}", "", "Current text:", text, "", "Findings to address:"]
+    for n, i in enumerate(issues, 1):
+        lines.append(f"{n}. [{i.get('severity', '')}] {i.get('issue', '')} — {i.get('detail', '')}")
+    if general_issues:
+        lines += ["", "Manuscript-wide findings (address only if they affect this section):"]
+        for i in general_issues:
+            lines.append(f"- [{i.get('severity', '')}] {i.get('issue', '')} — {i.get('detail', '')}")
+    if study_metadata:
+        lines += ["", "STUDY CONTEXT (do not contradict or exceed this):", _format_study(study_metadata)]
+    lines += ["", f"Rewrite the {section} section addressing these findings, following all rules."]
+    return "\n".join(lines)
+
+
+async def revise_manuscript(
+    sections: dict,
+    reviews=None,
+    check_issues=None,
+    *,
+    results_data=None,
+    available_figures=None,
+    study_metadata=None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+    max_passes: int = 2,
+    on_progress=None,
+) -> tuple[dict, list]:
+    """Revise sections to address review findings + deterministic checks.
+
+    Groups findings by section, rewrites each affected section, and re-runs the
+    deterministic checks between passes — stopping early for a section once its
+    deterministic issues clear or the model reports no change (bounded by
+    ``max_passes``). Returns ``(revised_sections, change_log)``. Degrades to the
+    original sections when no LLM is reachable and never mutates the input dict.
+    """
+    from .manuscript_checks import run_all_checks
+
+    revised = dict(sections)
+    change_log: list[dict] = []
+
+    async def emit(msg):
+        if on_progress:
+            await on_progress(msg)
+
+    # Reviewer findings + deterministic checks, merged into one issue list
+    issues = flatten_review_comments(reviews)
+    if check_issues is None:
+        check_issues = run_all_checks(sections, results_data, available_figures)
+    issues += check_issues
+    if not issues:
+        return revised, change_log
+
+    section_names = set(revised.keys())
+    general = [i for i in issues if i.get("section") not in section_names]
+    by_section: dict[str, list] = {}
+    for i in issues:
+        sec = i.get("section")
+        if sec in section_names:
+            by_section.setdefault(sec, []).append(i)
+
+    client = get_client(base_url=base_url, api_key=api_key)
+
+    for sec, sec_issues in by_section.items():
+        changed = False
+        passes = 0
+        remaining = sec_issues
+        errored = None
+        for _ in range(max_passes):
+            if not remaining:
+                break
+            passes += 1
+            prompt = _build_revise_prompt(sec, revised[sec], remaining, general, study_metadata)
+            try:
+                response = await _achat(client, REVISE_INSTRUCTIONS, prompt, model=model, max_tokens=8000)
+            except Exception as e:
+                log.warning(f"Revise LLM call failed for '{sec}': {e}")
+                errored = str(e)
+                break
+            text = _strip_think(response or "").strip()
+            if not text or text.upper().startswith("NO CHANGES NEEDED"):
+                break
+            text = _strip_code_fences(text)
+            if text and text != revised[sec]:
+                revised[sec] = text
+                changed = True
+            # Re-run deterministic checks scoped to this section for early-stop
+            recheck = run_all_checks({sec: revised[sec]}, results_data, available_figures)
+            remaining = [i for i in recheck if i.get("section") == sec]
+
+        entry = {"section": sec, "changed": changed, "passes": passes,
+                 "issues": len(sec_issues), "remaining_checks": len(remaining)}
+        if errored:
+            entry["error"] = errored
+        change_log.append(entry)
+        await emit(f"Revised {sec} ({'changed' if changed else 'no change'})")
+
+    return revised, change_log

--- a/portal/app/config.py
+++ b/portal/app/config.py
@@ -38,6 +38,13 @@ class Settings(BaseSettings):
     # Claude API (for production — falls back to llm_* settings if empty)
     anthropic_api_key: str = ""
 
+    # Manuscript revise loop (issue #20). When enabled, after review agents run
+    # the portal feeds their findings + deterministic checks back into a section
+    # rewrite. Off by default — reviews always produce PRs regardless (the
+    # "agents always help, never block" principle); revise is purely additive.
+    manuscript_revise_enabled: bool = False
+    manuscript_revise_max_passes: int = 2
+
     # Database
     database_url: str = "sqlite+aiosqlite:///./omc.db"
 

--- a/portal/app/reviews.py
+++ b/portal/app/reviews.py
@@ -173,6 +173,30 @@ async def run_reviews(
     # Store review results and PR URLs in interview_data
     interview_data["_reviews"] = reviews
     interview_data["_review_prs"] = pr_urls
+
+    # Optional revise pass (issue #20): feed review findings + deterministic
+    # checks back into a section rewrite. Off by default and purely additive —
+    # the original manuscript and the review PRs above are left untouched; the
+    # revised draft is stored separately for the author to accept or discard.
+    revise_log = None
+    if settings.manuscript_revise_enabled:
+        try:
+            from ai.manuscript_generator import revise_manuscript
+            revised, revise_log = await revise_manuscript(
+                manuscript,
+                reviews=reviews,
+                results_data=pipeline_outputs,
+                study_metadata=dict(submission.sample_metadata or {}),
+                base_url=llm["base_url"],
+                api_key=llm["api_key"],
+                model=llm["model"],
+                max_passes=settings.manuscript_revise_max_passes,
+            )
+            interview_data["_manuscript_revised"] = revised
+            interview_data["_revise_log"] = revise_log
+        except Exception as e:
+            logger.warning(f"Revise pass failed for {slug} (reviews preserved): {e}")
+
     submission.interview_data = interview_data
     attributes.flag_modified(submission, "interview_data")
     await db.commit()
@@ -181,6 +205,7 @@ async def run_reviews(
         "slug": slug,
         "reviews": reviews,
         "pull_requests": pr_urls,
+        "revise_log": revise_log,
     }
 
 

--- a/tests/test_manuscript_revise.py
+++ b/tests/test_manuscript_revise.py
@@ -1,0 +1,165 @@
+"""Tests for deterministic checks + the revise loop (issue #20).
+
+The check tests are pure. The revise tests are made deterministic either by
+monkeypatching the LLM call with a canned rewrite, or by pointing it at a
+fast-fail address to exercise graceful degradation — no live LLM/network.
+"""
+import sys
+import pytest
+
+sys.path.insert(0, "/data/omc/omc-platform")
+
+NO_LLM = "http://127.0.0.1:9/v1"
+
+_LONG = "x" * 150  # padding to clear the thin-section (<100 char) check
+
+
+# ---------------------------------------------------------------------------
+# Deterministic checks
+# ---------------------------------------------------------------------------
+
+def test_check_placeholders_finds_and_grades():
+    from ai.manuscript_checks import check_placeholders
+    sections = {
+        "introduction": "A claim [CITE]. Another [CITE: Smith 2020]. A gap [AUTHOR: describe site].",
+        "methods": "We used tools [CITATION NEEDED] and [TODO fill in].",
+    }
+    issues = check_placeholders(sections)
+    kinds = {(i["section"], i["severity"]) for i in issues}
+    # [CITE] variants are "major"; [AUTHOR:]/[CITATION NEEDED]/[TODO] are "critical"
+    assert ("introduction", "major") in kinds
+    assert ("introduction", "critical") in kinds
+    assert ("methods", "critical") in kinds
+    # [CITE] and [CITE: ...] dedupe to one token form each within a section
+    intro_cite = [i for i in issues if i["section"] == "introduction" and i["severity"] == "major"]
+    assert len(intro_cite) == 2  # "[CITE]" and "[CITE: Smith 2020]" are distinct tokens
+
+
+def test_check_required_sections():
+    from ai.manuscript_checks import check_required_sections
+    sections = {
+        "abstract": _LONG, "introduction": _LONG, "methods": _LONG,
+        "results": "too short", "discussion": "",
+    }
+    issues = check_required_sections(sections)
+    by = {i["section"]: i["issue"] for i in issues}
+    assert by["results"] == "thin-section"
+    assert by["discussion"] == "missing-section"
+    assert "abstract" not in by
+
+
+def test_check_figure_references():
+    from ai.manuscript_checks import check_figure_references
+    # Text references Figure 3 but only 2 figures exist → mismatch
+    over = check_figure_references({"results": "See Figure 1 and Figure 3."},
+                                   available_figures=["a", "b"])
+    assert any(i["issue"] == "figure-reference-mismatch" for i in over)
+    # Figures exist but none referenced → unused
+    unused = check_figure_references({"results": "No figures mentioned here."},
+                                     available_figures=["a", "b"])
+    assert any(i["issue"] == "unused-figures" for i in unused)
+    # No available figures → no issues
+    assert check_figure_references({"results": "See Figure 9."}, available_figures=[]) == []
+
+
+def test_check_numbers_supported():
+    from ai.manuscript_checks import check_numbers_supported
+    data = {"completeness": 98.6, "bins": 12, "coverage_pct": 45}
+    sections = {
+        "results": "Recovered a MAG at 98.6% completeness and 3.2% contamination in 2021.",
+        "abstract": "We report 45% coverage.",
+    }
+    issues = check_numbers_supported(sections, data)
+    # 98.6 is in the data (supported); 3.2 is not (flag); 2021 is a year (ignored)
+    results_issue = [i for i in issues if i["section"] == "results"]
+    assert results_issue and "3.2%" in results_issue[0]["detail"]
+    assert "98.6" not in results_issue[0]["detail"]
+    # 45% appears in the data as 45 → abstract is clean
+    assert not any(i["section"] == "abstract" for i in issues)
+    # No data → no checks
+    assert check_numbers_supported(sections, None) == []
+
+
+def test_run_all_checks_combines():
+    from ai.manuscript_checks import run_all_checks
+    sections = {"introduction": f"Intro [CITE]. {_LONG}"}
+    issues = run_all_checks(sections, results_data=None, available_figures=None)
+    kinds = {i["issue"] for i in issues}
+    assert "unresolved-placeholder" in kinds
+    assert "missing-section" in kinds  # abstract/methods/results/discussion absent
+
+
+# ---------------------------------------------------------------------------
+# flatten_review_comments
+# ---------------------------------------------------------------------------
+
+def test_flatten_review_comments():
+    from ai.manuscript_generator import flatten_review_comments
+    reviews = [{
+        "review_type": "clarity",
+        "comments": [{"section": "Results", "issue": "vague", "detail": "d",
+                      "severity": "minor", "confidence": 0.4}],
+        "summary": "s",
+    }]
+    flat = flatten_review_comments(reviews)
+    assert flat[0]["section"] == "results"   # lowercased
+    assert flat[0]["source"] == "clarity"
+    assert len(flat) == 1
+
+
+# ---------------------------------------------------------------------------
+# revise_manuscript
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_revise_no_issues_is_noop():
+    from ai.manuscript_generator import revise_manuscript
+    sections = {s: _LONG for s in
+                ["abstract", "introduction", "methods", "results", "discussion"]}
+    revised, log = await revise_manuscript(sections, reviews=None, base_url=NO_LLM)
+    assert revised == sections
+    assert log == []
+
+
+@pytest.mark.asyncio
+async def test_revise_applies_rewrite(monkeypatch):
+    import ai.manuscript_generator as mg
+
+    async def fake_achat(client, system, user, model=None, max_tokens=8000):
+        return "Clean introduction text with no placeholders whatsoever. " + _LONG
+
+    monkeypatch.setattr(mg, "_achat", fake_achat)
+    sections = {"introduction": f"Intro with a leftover [AUTHOR: describe study] note. {_LONG}"}
+    revised, log = await mg.revise_manuscript(sections, base_url=NO_LLM, max_passes=2)
+
+    assert "[AUTHOR" not in revised["introduction"]
+    intro_log = [e for e in log if e["section"] == "introduction"]
+    assert intro_log and intro_log[0]["changed"] is True
+    assert intro_log[0]["passes"] == 1  # early-stop: placeholder cleared after one pass
+
+
+@pytest.mark.asyncio
+async def test_revise_strips_code_fences(monkeypatch):
+    import ai.manuscript_generator as mg
+
+    async def fake_achat(client, system, user, model=None, max_tokens=8000):
+        return "```markdown\nFenced revised methods content. " + _LONG + "\n```"
+
+    monkeypatch.setattr(mg, "_achat", fake_achat)
+    sections = {"methods": f"Methods with [TODO expand]. {_LONG}"}
+    revised, _ = await mg.revise_manuscript(sections, base_url=NO_LLM)
+    assert not revised["methods"].startswith("```")
+    assert "Fenced revised methods content" in revised["methods"]
+
+
+@pytest.mark.asyncio
+async def test_revise_degrades_without_llm():
+    from ai.manuscript_generator import revise_manuscript
+    sections = {"introduction": f"Intro with [AUTHOR: gap]. {_LONG}"}
+    original = dict(sections)
+    revised, log = await revise_manuscript(sections, base_url=NO_LLM)
+    # LLM unreachable → section unchanged, error recorded, input not mutated
+    assert revised["introduction"] == original["introduction"]
+    assert sections == original
+    intro_log = [e for e in log if e["section"] == "introduction"]
+    assert intro_log and "error" in intro_log[0]


### PR DESCRIPTION
## Summary

Closes the review→revise loop (issue #20): the six review agents already produced structured findings but they dead-ended into PRs. This feeds those findings — plus **deterministic, machine-verifiable checks** — back into a bounded section rewrite, OMC's analog of AI-Scientist's reflection loop.

## What changed

- **`ai/manuscript_checks.py`** (new) — no-LLM checks that ground the loop with concrete defects instead of "make it better":
  - leftover `[CITE]` / `[AUTHOR:]` / `[CITATION NEEDED]` / `[TODO]` placeholders
  - numbered figure references vs. the figures actually generated from pipeline data
  - precise numbers (decimals/percentages) in Abstract/Results absent from the pipeline data
  - missing or suspiciously thin required sections
  Each returns a review-comment-shaped issue so reviewer and check findings are consumed uniformly.
- **`revise_manuscript()`** — groups findings by section, rewrites each affected section, and re-runs the checks between passes to **early-stop** once a section's deterministic issues clear (bounded by `max_passes`). Reuses the anti-fabrication rules, degrades to the original sections when no LLM is reachable, and never mutates its input.
- **Portal wiring** — gated by `manuscript_revise_enabled` (**default off**). Purely additive: the original manuscript and the review PRs are untouched; the revised draft is stored under `_manuscript_revised` for the author to accept or discard.

## Tests

`tests/test_manuscript_revise.py` — 10 deterministic tests (no LLM/network) covering every check, `flatten_review_comments`, and the revise pass (rewrite applied, code-fence stripping, early-stop, no-op, graceful no-LLM degradation).

Reviews still produce PRs exactly as before — no regression to the existing flow.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
