### PR TITLE
config: per-role model selection for draft / cite / review (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,11 @@ All settings via environment or `.env` (see `portal/app/config.py`):
 |----------|---------|-------------|
 | `LLM_BASE_URL` | `http://10.151.49.182:1234/v1` | OpenAI-compatible API |
 | `LLM_MODEL` | `qwen/qwen3.5-35b-a3b` | Model for AI features |
+| `LLM_MODEL_DRAFT` | (falls back to `LLM_MODEL`) | Model for manuscript drafting + revise |
+| `LLM_MODEL_CITE` | (falls back to `LLM_MODEL`) | Model for citation resolution (high-volume; use a cheap/local model) |
+| `LLM_MODEL_REVIEW` | (falls back to `LLM_MODEL`) | Model for the review agents |
+| `MANUSCRIPT_REVISE_ENABLED` | `false` | Run the review→revise loop after reviews (additive; stores `_manuscript_revised`) |
+| `MANUSCRIPT_REVISE_MAX_PASSES` | `2` | Max rewrite passes per section in the revise loop |
 | `GITHUB_APP_ID` | | GitHub App numeric ID |
 | `GITHUB_APP_PRIVATE_KEY` | | PEM file path or content |
 | `GITHUB_ORG` | `open-community-science` | Org for paper repos |
@@ -424,6 +429,11 @@ The portal's `.env` on arbutus sets `LLM_BASE_URL=http://localhost:1234/v1`. Ses
 SECRET_KEY=<random>
 LLM_BASE_URL=http://localhost:1234/v1   # via reverse SSH tunnel from concentration
 LLM_MODEL=qwen/qwen3.5-35b-a3b
+# Optional per-role model overrides (default to LLM_MODEL when unset):
+# LLM_MODEL_DRAFT=qwen/qwen3.5-35b-a3b   # drafting + revise
+# LLM_MODEL_CITE=qwen/qwen3-4b            # cheap/local model for citation rounds
+# LLM_MODEL_REVIEW=qwen/qwen3.5-35b-a3b   # review agents
+# MANUSCRIPT_REVISE_ENABLED=false         # opt-in review→revise loop
 GITHUB_APP_ID=3078928
 GITHUB_APP_PRIVATE_KEY=<pem path>
 GITHUB_ORG=open-community-science

--- a/ai/manuscript_generator.py
+++ b/ai/manuscript_generator.py
@@ -127,11 +127,16 @@ async def generate_manuscript_draft(
     base_url: str | None = None,
     api_key: str | None = None,
     model: str | None = None,
+    cite_model: str | None = None,
     on_progress=None,
 ) -> dict:
     """
     Generate a manuscript draft from pipeline outputs and author interview.
 
+    model: model used for drafting the sections.
+    cite_model: model used for citation resolution (issue #21) — falls back to
+                `model` when unset, so the high-volume citation loop can run on a
+                cheaper/local model than the drafting.
     on_progress: optional async callable(event, detail) for streaming progress.
     Returns a dict with sections: abstract, introduction, methods, results, discussion
     """
@@ -303,7 +308,7 @@ Write a single paragraph (200-300 words) covering:
             search_fn=search_pubmed,
             base_url=base_url,
             api_key=api_key,
-            model=model,
+            model=cite_model or model,
         )
         if bibliography:
             sections["bibliography"] = bibliography

--- a/portal/app/config.py
+++ b/portal/app/config.py
@@ -35,6 +35,14 @@ class Settings(BaseSettings):
     llm_api_key: str = "lm-studio"
     llm_model: str = "qwen/qwen3.5-35b-a3b"
 
+    # Per-role model overrides (issue #21). Each falls back to llm_model when
+    # unset, so single-model setups are unaffected. Lets an operator point the
+    # cheap/high-volume citation loop at a small/local model while drafting and
+    # review use a stronger one — and enables local-vs-remote model comparisons.
+    llm_model_draft: str = ""
+    llm_model_cite: str = ""
+    llm_model_review: str = ""
+
     # Claude API (for production — falls back to llm_* settings if empty)
     anthropic_api_key: str = ""
 
@@ -112,6 +120,19 @@ class Settings(BaseSettings):
     def admin_logins(self) -> set[str]:
         """Parsed, lowercased set of admin GitHub logins."""
         return {x.strip().lower() for x in self.admin_github_logins.split(",") if x.strip()}
+
+    def role_model(self, role: str, default: str = "") -> str:
+        """Model for an AI role ('draft' | 'cite' | 'review'), or `default`.
+
+        Returns the per-role override when configured, else `default` (the
+        caller's resolved model) so per-user backend choices still apply.
+        """
+        override = {
+            "draft": self.llm_model_draft,
+            "cite": self.llm_model_cite,
+            "review": self.llm_model_review,
+        }.get(role, "")
+        return override or default
 
     class Config:
         env_file = ".env"

--- a/portal/app/pipeline_processing.py
+++ b/portal/app/pipeline_processing.py
@@ -195,7 +195,8 @@ async def process_completed_submission(submission: Submission, db_session) -> st
                 bioproject_accession=submission.bioproject_accession,
                 base_url=settings.llm_base_url,
                 api_key=settings.llm_api_key,
-                model=settings.llm_model,
+                model=settings.role_model("draft", settings.llm_model),
+                cite_model=settings.role_model("cite", settings.llm_model),
             )
         except Exception as e:
             logger.warning(f"AI generation failed, using placeholders: {e}")

--- a/portal/app/reviews.py
+++ b/portal/app/reviews.py
@@ -143,7 +143,7 @@ async def run_reviews(
         pipeline_config,
         base_url=llm["base_url"],
         api_key=llm["api_key"],
-        model=llm["model"],
+        model=settings.role_model("review", llm["model"]),
     )
 
     # Create PRs if the paper has a GitHub repo
@@ -189,7 +189,7 @@ async def run_reviews(
                 study_metadata=dict(submission.sample_metadata or {}),
                 base_url=llm["base_url"],
                 api_key=llm["api_key"],
-                model=llm["model"],
+                model=settings.role_model("draft", llm["model"]),
                 max_passes=settings.manuscript_revise_max_passes,
             )
             interview_data["_manuscript_revised"] = revised
@@ -279,7 +279,8 @@ async def generate_manuscript(
         study_metadata=dict(submission.sample_metadata or {}),
         base_url=llm["base_url"],
         api_key=llm["api_key"],
-        model=llm["model"],
+        model=settings.role_model("draft", llm["model"]),
+        cite_model=settings.role_model("cite", llm["model"]),
     )
 
     # Store manuscript in interview_data (but don't publish yet)
@@ -376,7 +377,8 @@ async def generate_manuscript_stream(
                     study_metadata=sub_study_meta,
                     base_url=llm["base_url"],
                     api_key=llm["api_key"],
-                    model=llm["model"],
+                    model=settings.role_model("draft", llm["model"]),
+                    cite_model=settings.role_model("cite", llm["model"]),
                     on_progress=on_progress,
                 )
                 result_holder["sections"] = sections

--- a/tests/test_role_models.py
+++ b/tests/test_role_models.py
@@ -1,0 +1,86 @@
+"""Tests for per-role model selection (issue #21).
+
+Verifies the config-level override resolution and that the citation model is
+threaded independently of the drafting model through generate_manuscript_draft.
+"""
+import sys
+import pytest
+
+sys.path.insert(0, "/data/omc/omc-platform")
+
+NO_LLM = "http://127.0.0.1:9/v1"
+
+
+# ---------------------------------------------------------------------------
+# Settings.role_model
+# ---------------------------------------------------------------------------
+
+def test_role_model_prefers_override_else_default():
+    from portal.app.config import Settings
+    s = Settings(llm_model="m-base", llm_model_cite="m-cheap", llm_model_review="m-rev")
+    # explicit overrides win
+    assert s.role_model("cite", "resolved") == "m-cheap"
+    assert s.role_model("review", "resolved") == "m-rev"
+    # no draft override → the caller's resolved model is used
+    assert s.role_model("draft", "resolved") == "resolved"
+    # unknown role → default
+    assert s.role_model("nope", "resolved") == "resolved"
+
+
+def test_role_model_defaults_are_empty_so_behaviour_is_unchanged():
+    from portal.app.config import Settings
+    s = Settings(llm_model="m-base")
+    for role in ("draft", "cite", "review"):
+        assert s.role_model(role, "resolved") == "resolved"
+
+
+# ---------------------------------------------------------------------------
+# cite_model threading through generate_manuscript_draft
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generate_forwards_cite_model(monkeypatch):
+    import ai.manuscript_generator as mg
+
+    async def fake_achat(client, system, user, model=None, max_tokens=20000, on_token=None):
+        return "Section text."
+
+    captured = {}
+
+    async def fake_resolve(sections, **kwargs):
+        captured["model"] = kwargs.get("model")
+        return sections, ""
+
+    monkeypatch.setattr(mg, "_achat", fake_achat)
+    monkeypatch.setattr(mg, "resolve_citations", fake_resolve)
+
+    await mg.generate_manuscript_draft(
+        pipeline_outputs={}, interview_data={}, pipeline_type="nanopore_mag",
+        bioproject_accession="PRJNA000", base_url=NO_LLM,
+        model="draft-model", cite_model="cite-model",
+    )
+    assert captured["model"] == "cite-model"
+
+
+@pytest.mark.asyncio
+async def test_cite_model_falls_back_to_draft_model(monkeypatch):
+    import ai.manuscript_generator as mg
+
+    async def fake_achat(client, system, user, model=None, max_tokens=20000, on_token=None):
+        return "Section text."
+
+    captured = {}
+
+    async def fake_resolve(sections, **kwargs):
+        captured["model"] = kwargs.get("model")
+        return sections, ""
+
+    monkeypatch.setattr(mg, "_achat", fake_achat)
+    monkeypatch.setattr(mg, "resolve_citations", fake_resolve)
+
+    await mg.generate_manuscript_draft(
+        pipeline_outputs={}, interview_data={}, pipeline_type="nanopore_mag",
+        bioproject_accession="PRJNA000", base_url=NO_LLM,
+        model="draft-model",  # cite_model unset
+    )
+    assert captured["model"] == "draft-model"


### PR DESCRIPTION
## Summary

Per-role model selection (issue #21): the harness used a single `LLM_MODEL` for drafting, citation, and review. This adds three optional overrides so an operator can point cheap/high-volume work (the citation rounds) at a small/local model while drafting and review use a stronger one — and, directly, so we can run head-to-head local-vs-remote model comparisons.

## What changed

- **`config.py`** — `LLM_MODEL_DRAFT`, `LLM_MODEL_CITE`, `LLM_MODEL_REVIEW`, each **defaulting to `LLM_MODEL` when unset** (fully backward compatible), plus a `Settings.role_model(role, default)` resolver that prefers the override else the caller's resolved per-user backend model.
- **`generate_manuscript_draft`** — gains a `cite_model` param, forwarded to `resolve_citations` (falls back to the draft model), so citation resolution can run on a different model than drafting.
- **Portal call sites** — `/generate`, `/generate-stream`, the `run_reviews` revise pass, and `pipeline_processing` thread the role-appropriate model through `role_model()`. Reviews use the review model; drafting/revise use the draft model; citations use the cite model.
- **Docs** — CLAUDE.md config table + `.env` example.

Defaults are empty → the resolved per-user model is used everywhere exactly as before. No behavior change unless an operator sets an override.

## Tests

`tests/test_role_models.py` — 4 tests: override-vs-default resolution, empty-default backward compatibility, and `cite_model` threading through `generate_manuscript_draft` (explicit + fallback).

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
