### PR TITLE
Fix Codex review findings #31–#34 (citation swap, collection_date, local model id, status race)

### DIFF
--- a/ai/manuscript_generator.py
+++ b/ai/manuscript_generator.py
@@ -493,7 +493,7 @@ async def resolve_citations(
 
     search = _make_searcher(search_fn, candidates_per_query) if search_fn else None
     library = CitationLibrary()
-    replacements = []  # (original_text, replacement_text)
+    edits = []  # (start, end, replacement) into the ORIGINAL full_text
 
     for i, ctx in enumerate(contexts):
         # queries only covers the first batch of contexts; fall back for the rest
@@ -534,12 +534,13 @@ async def resolve_citations(
             inline = f"[{hint or f'ref{i+1}'}]"
             log.info(f"No citation resolved for placeholder {i+1}: '{query}'")
 
-        original = full_text[ctx["span"][0]:ctx["span"][1]]
-        replacements.append((original, inline))
+        edits.append((ctx["span"][0], ctx["span"][1], inline))
 
-    # Apply replacements in reverse order to preserve spans
-    for original, replacement in reversed(replacements):
-        full_text = full_text.replace(original, replacement, 1)
+    # Apply by span, right-to-left, so identical placeholder strings (bare [CITE])
+    # each get THEIR chosen citation. A text-based replace(original, ..., 1) would
+    # always hit the first remaining occurrence and mis-assign papers (issue #34).
+    for start, end, replacement in sorted(edits, key=lambda e: e[0], reverse=True):
+        full_text = full_text[:start] + replacement + full_text[end:]
 
     # Split back into sections
     updated_sections = {}

--- a/portal/app/llm_backends.py
+++ b/portal/app/llm_backends.py
@@ -139,9 +139,14 @@ async def resolve_llm(user: User | None) -> dict:
         }
 
     async def _local() -> dict:
+        # Honour any model the local server actually serves — provider validity is
+        # NOT inferable from a "/" in the id (e.g. 'codeqwen3-14b', 'gpt-oss-20b'
+        # are valid local ids). Fall back only when empty, a hosted ':free' id, or
+        # the saved id is no longer served (issue #32).
         model = chosen_model
-        if not model or "/" not in model or model.endswith(":free"):
-            model = recommended_local_model(await list_local_models())
+        available = await list_local_models()
+        if not model or model.endswith(":free") or (available and model not in available):
+            model = recommended_local_model(available)
         return {
             "backend": BACKEND_LOCAL, "base_url": settings.llm_base_url,
             "api_key": settings.llm_api_key, "model": model,

--- a/portal/app/slurm.py
+++ b/portal/app/slurm.py
@@ -120,7 +120,11 @@ def _microscape_metadata_prelude(submission: Submission) -> tuple[str, str]:
         ("center_name", "center_name"),
         ("read_count", "read_count"),
         ("base_count", "base_count"),
-        ("collection_date", "first_created"),
+        # collection_date must be the biological SAMPLING date, not ENA's record
+        # creation time (first_created) — else temporal/ecological grouping is wrong
+        # (issue #33). Keep first_created in its own column for provenance.
+        ("collection_date", "collection_date"),
+        ("first_created", "first_created"),
     ]
 
     def _clean(v) -> str:

--- a/portal/app/submissions.py
+++ b/portal/app/submissions.py
@@ -290,9 +290,16 @@ async def get_status(
                 await db.commit()
                 s = "processing"
             elif phase == "transferred":
-                submission.status = SubmissionStatus.RESULTS_READY
+                # Do NOT set RESULTS_READY here. The finalization for a transferred
+                # run — empty-archive → FAILED guard, results_format, and microscape
+                # viz deployment — lives only in poll_all_running_jobs, which selects
+                # PROCESSING rows. If this fast page poll set RESULTS_READY first, the
+                # background poller would never select the row and that finalization
+                # (validation + deploy) would be skipped (issue #31). Advance only to
+                # PROCESSING and let the authoritative poller finalize.
+                submission.status = SubmissionStatus.PROCESSING
                 await db.commit()
-                s = "results_ready"
+                s = "processing"
             elif phase == "failed":
                 submission.status = SubmissionStatus.FAILED
                 submission.error_message = hpc_status.get("reason", f"Exit code {hpc_status.get('exit_code', '?')}")

--- a/tests/test_codex_review_fixes.py
+++ b/tests/test_codex_review_fixes.py
@@ -1,0 +1,88 @@
+"""Regression tests for the Codex review findings #32, #33, #34.
+
+Deterministic and offline: no live LLM or network. LLM-dependent steps point at a
+dead address so they fall back, and selection/search are mocked.
+"""
+import asyncio
+import base64
+import re
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+NO_LLM = "http://127.0.0.1:9/v1"
+
+
+def _article(title, author, year):
+    return {"title": title, "authors": [author], "year": str(year), "journal": "J",
+            "volume": "1", "pages": "1-2", "doi": f"d{year}", "pmid": str(year)}
+
+
+# ── #34: identical [CITE] placeholders keep their OWN citation ────────────────
+def test_citations_not_swapped_between_identical_placeholders(monkeypatch):
+    import ai.manuscript_generator as mg
+    import ai.citation_resolver as cr
+
+    alpha, beta = _article("Alpha", "Aaa", 2001), _article("Beta", "Bbb", 2002)
+
+    def search_fn(query):                       # distinct paper per placeholder
+        return [alpha] if "first" in query.lower() else [beta]
+
+    async def fake_select(ctx, candidates, **kw):
+        return candidates[0]
+    monkeypatch.setattr(cr, "select_citation", fake_select)
+
+    sections = {"results": "First claim [CITE]. Second claim [CITE]."}
+    out, _bib = asyncio.run(mg.resolve_citations(sections, search_fn=search_fn, base_url=NO_LLM))
+    text = out["results"]
+    # Alpha (2001) must stay with the FIRST claim, Beta (2002) with the SECOND —
+    # not swapped by a text-based replace() on identical '[CITE]' strings.
+    assert "First claim (Aaa, 2001)" in text, text
+    assert "Second claim (Bbb, 2002)" in text, text
+    assert text.index("2001") < text.index("2002"), text
+
+
+# ── #32: local backend keeps a served model id without a slash ────────────────
+def test_local_backend_keeps_slashless_served_model(monkeypatch):
+    import portal.app.llm_backends as lb
+    from portal.app.database import User
+
+    async def fake_list():
+        return ["codeqwen3-14b", "qwen/qwen3-coder-30b"]
+    monkeypatch.setattr(lb, "list_local_models", fake_list)
+
+    user = User(llm_backend=lb.BACKEND_LOCAL, llm_model="codeqwen3-14b")
+    res = asyncio.run(lb.resolve_llm(user))
+    assert res["backend"] == lb.BACKEND_LOCAL
+    assert res["model"] == "codeqwen3-14b"       # preserved, not swapped for the first
+
+
+def test_local_backend_falls_back_when_saved_model_not_served(monkeypatch):
+    import portal.app.llm_backends as lb
+    from portal.app.database import User
+
+    async def fake_list():
+        return ["qwen/qwen3-coder-30b"]
+    monkeypatch.setattr(lb, "list_local_models", fake_list)
+
+    user = User(llm_backend=lb.BACKEND_LOCAL, llm_model="no-longer-served")
+    res = asyncio.run(lb.resolve_llm(user))
+    assert res["model"] == "qwen/qwen3-coder-30b"
+
+
+# ── #33: metadata TSV uses the biological collection_date ─────────────────────
+def test_metadata_prelude_uses_collection_date_not_first_created():
+    from portal.app.slurm import _microscape_metadata_prelude
+
+    sub = types.SimpleNamespace(sample_metadata={"sample_records": [
+        {"run_accession": "SRR1", "collection_date": "2025-06-15", "first_created": "2026-01-20"},
+    ]})
+    prelude, _args = _microscape_metadata_prelude(sub)
+    blob = re.search(r"printf '%s' '([A-Za-z0-9+/=]+)'", prelude).group(1)
+    tsv = base64.b64decode(blob).decode()
+    header, row = tsv.strip().split("\n")
+    vals = dict(zip(header.split("\t"), row.split("\t")))
+    assert vals["collection_date"] == "2025-06-15"   # sampling date, not record-creation
+    assert vals["first_created"] == "2026-01-20"      # kept in its own column


### PR DESCRIPTION
Addresses the four issues Codex filed after the #30 merge. Each is a real, verified bug; three ship with regression tests (the fourth needs async db/route fixtures — noted below).

## #34 — Citation resolver swaps papers between identical `[CITE]` placeholders (correctness)
`resolve_citations` recorded `(original_text, replacement)` and applied `full_text.replace(original, replacement, 1)` in reverse. For identical bare `[CITE]` strings, `replace(..., 1)` always hits the first remaining occurrence, so reversing the list **reversed the citation assignments** — a real PubMed paper gets cited next to a different claim than the one it was selected for.
**Fix:** apply edits by their recorded `(start, end)` spans, right-to-left. **Test:** two bare `[CITE]` resolving to different papers stay correctly assigned.

## #33 — Microscape metadata records creation time as `collection_date` (scientific correctness)
The metadata TSV mapped the `collection_date` column to ENA's `first_created` (record-creation date), replacing the biological sampling date. Downstream temporal/ecological grouping and Methods text then use the wrong date. *(This is exactly the confound I hit in the autoresearch prototype — "temporal groups" split on `collection_date`.)*
**Fix:** map `collection_date → collection_date`; keep `first_created` in its own column for provenance. **Test:** TSV emits the sampling date.

## #32 — Local backend ignores model ids without a slash
`resolve_llm._local` did `if not model or "/" not in model or ...` and silently replaced valid served ids like `codeqwen3-14b`/`gpt-oss-20b` with the recommended one — so a user's saved model and the model that actually ran could differ (misleading provenance, unreliable A/B).
**Fix:** honour any id the local server actually serves; fall back only when empty, a hosted `:free` id, or no longer served. **Tests:** slashless served id is preserved; a stale id falls back.

## #31 — Status polling can bypass microscape validation & deployment (race)
The 10s page poll (`submissions.get_status`) set `RESULTS_READY` on `transferred`, but the empty-archive→FAILED guard, `results_format`, and viz deployment only run in `poll_all_running_jobs`, which selects `PROCESSING` rows. Once the route wrote `RESULTS_READY`, the background poller never selected the row and finalization was permanently skipped — so an empty archive could read as ready, or a valid run could miss its viz link, just because the author had the page open.
**Fix:** the route advances only to `PROCESSING` and lets the authoritative background poller finalize (validate + deploy) before `RESULTS_READY`. **Test:** a route-observes-`transferred`-first regression test needs async db + route fixtures; flagged as a follow-up.

All new + adjacent tests pass (`test_codex_review_fixes.py`, `test_citation_library.py`, `test_role_models.py`).

Fixes #31, #32, #33, #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)