### PR TITLE
Productionize autoresearch: driveable from the website (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ All settings via environment or `.env` (see `portal/app/config.py`):
 | `AUTORESEARCH_MAX_STEPS` | `48` | Agent tool-call budget per run |
 | `AUTORESEARCH_MAX_FOLLOWUPS` | `12` | Cap on self-added agenda items |
 | `AUTORESEARCH_TIME_BUDGET_S` | `1800` | Wall-clock cap on the explore loop |
-| `AUTORESEARCH_MAX_ANALYSIS_S` | `60` | Per `run_analysis` exec timeout (inside the session jail) |
+| `AUTORESEARCH_MAX_ANALYSIS_S` | `60` | Per `run_analysis` exec timeout (inside the session sandbox) |
 | `AUTORESEARCH_RECONCILE_ENABLED` | `true` | Skeptical-model fallback when deterministic verify misses |
 | `AUTORESEARCH_COMMIT_ENABLED` | `false` | PR the verified Results prose to the paper repo `.omc/` |
 | `LLM_MODEL_EXPLORE` | (falls back to `LLM_MODEL`) | Model for the autoresearch agent loop |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,15 @@ All settings via environment or `.env` (see `portal/app/config.py`):
 | `LLM_MODEL_REVIEW` | (falls back to `LLM_MODEL`) | Model for the review agents |
 | `MANUSCRIPT_REVISE_ENABLED` | `false` | Run the review→revise loop after reviews (additive; stores `_manuscript_revised`) |
 | `MANUSCRIPT_REVISE_MAX_PASSES` | `2` | Max rewrite passes per section in the revise loop |
+| `AUTORESEARCH_ENABLED` | `false` | Enable claim-grounded autoresearch (issue #29); gates the route + Step 3 trigger |
+| `AUTORESEARCH_MAX_STEPS` | `48` | Agent tool-call budget per run |
+| `AUTORESEARCH_MAX_FOLLOWUPS` | `12` | Cap on self-added agenda items |
+| `AUTORESEARCH_TIME_BUDGET_S` | `1800` | Wall-clock cap on the explore loop |
+| `AUTORESEARCH_MAX_ANALYSIS_S` | `60` | Per `run_analysis` exec timeout (inside the session jail) |
+| `AUTORESEARCH_RECONCILE_ENABLED` | `true` | Skeptical-model fallback when deterministic verify misses |
+| `AUTORESEARCH_COMMIT_ENABLED` | `false` | PR the verified Results prose to the paper repo `.omc/` |
+| `LLM_MODEL_EXPLORE` | (falls back to `LLM_MODEL`) | Model for the autoresearch agent loop |
+| `LLM_MODEL_VERIFY` | (falls back to `LLM_MODEL`) | Model for the skeptical reconciler |
 | `GITHUB_APP_ID` | | GitHub App numeric ID |
 | `GITHUB_APP_PRIVATE_KEY` | | PEM file path or content |
 | `GITHUB_ORG` | `open-community-science` | Org for paper repos |
@@ -434,6 +443,11 @@ LLM_MODEL=qwen/qwen3.5-35b-a3b
 # LLM_MODEL_CITE=qwen/qwen3-4b            # cheap/local model for citation rounds
 # LLM_MODEL_REVIEW=qwen/qwen3.5-35b-a3b   # review agents
 # MANUSCRIPT_REVISE_ENABLED=false         # opt-in review→revise loop
+# Claim-grounded autoresearch (issue #29; off by default, needs .sqsh results):
+# AUTORESEARCH_ENABLED=false
+# AUTORESEARCH_COMMIT_ENABLED=false        # PR the Results prose to .omc/
+# LLM_MODEL_EXPLORE=qwen/qwen3.5-35b-a3b   # agent loop model
+# LLM_MODEL_VERIFY=qwen/qwen3.5-35b-a3b    # skeptical reconciler model
 GITHUB_APP_ID=3078928
 GITHUB_APP_PRIVATE_KEY=<pem path>
 GITHUB_ORG=open-community-science

--- a/ai/autoresearch.py
+++ b/ai/autoresearch.py
@@ -1,0 +1,941 @@
+"""Claim-grounded autoresearch core (issue #29) — reusable, injection-based.
+
+An agent EXPLORES pipeline data — reading summaries AND running its own analysis
+code — and records a ledger of VERIFIABLE claims. Claims are the currency: each
+links to its ANTECEDENTS (the data paths and/or the computations it depends on),
+forming a provenance **DAG**. Every claim is re-derivable — a data claim by
+re-reading its path, a computed claim by re-executing its stored code — so any
+other model or human can verify it. Results prose is written from verified claims
+only, with a two-layer check: deterministic re-execution first, a skeptical model
+reconciliation as the labelled fallback.
+
+This module is the production-shared core extracted from the ``tests/bench``
+prototype. It is portal-free and endpoint-free: everything talks to three injected
+collaborators —
+
+  * ``DataSource``   — reads the summary datasets and navigates data-path antecedents,
+  * ``LLMClient``    — an async OpenAI-compatible tool-calling client,
+  * ``CodeExecutor`` — runs (and, at verify time, RE-runs) model-written analysis code.
+
+The offline bench (``tests/bench/results_explorer.py``) constructs these with a
+``DirDataSource`` over local viz JSON, a ``SubprocessExecutor``, and an
+``LLMClient`` around a synchronous LM Studio / OpenRouter endpoint. The portal
+route injects a squashfuse-backed ``DirDataSource``, a ``ContainerExecutor``
+(``docker exec`` into the isolated session container), and ``resolve_llm``.
+
+All prototype module globals (DATASETS / COUNTS / TAX_DF / SAMPLES_META /
+COMPUTATIONS / LEDGER / AGENDA) collapse into ``Autoresearcher`` instance state so
+concurrent submissions are isolated.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as _datetime
+import gzip
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional, Protocol, runtime_checkable
+
+# ── Prompts (moved verbatim from the prototype) ───────────────────────────────
+EXPLORE_SYSTEM = """You are a curious microbial ecologist investigating a 16S/18S amplicon
+dataset. Your job is not to restate summary statistics — it is to TEST HYPOTHESES and find
+PATTERNS, RELATIONSHIPS, and ANOMALIES a scientist would care about, then ground each in a
+re-runnable computation.
+
+Work systematically and recursively:
+1. FIRST call propose_agenda with the analyses/hypothesis tests worth running here — the
+   standard microbial-ecology toolkit AND less obvious ideas. Think across: alpha diversity
+   (richness, Shannon, Simpson, Pielou evenness) and its dependence on sequencing depth;
+   dominance and the rare biosphere; beta-diversity structure (Bray-Curtis/Jaccard,
+   ordination) and WHICH taxa drive it; differential abundance / indicator taxa between
+   sample groups; co-occurrence; the prokaryote-vs-eukaryote split (use `tax` Domain);
+   core vs transient taxa (prevalence); and a contamination screen for known kit/reagent
+   genera (e.g. Ralstonia, Bradyrhizobium, Cutibacterium, Pelomonas, Delftia).
+2. Work the agenda item by item. For each: run_analysis over `counts`/`tax`/`meta` to test
+   it, then record_claim(s) with the exact value(s) and antecedents. mark_done and move on.
+3. RECURSE: whenever a result is surprising or opens a question, add_followup — that is how
+   you go deeper (a cluster in ordination → its driver taxa → are they contamination?).
+4. Prefer claims of kind "pattern" or "anomaly" (an insight) over "observation" (a restated
+   number). Be honest: record quality_caveat for depth bias, low evenness, contamination,
+   or anything that undermines a result. Never claim a number you did not compute.
+
+KNOW WHAT THE FIELDS MEAN, then think critically about the data:
+- `meta['x']`/`meta['y']` are PRECOMPUTED ORDINATION coordinates, not geographic lat/lon.
+- `meta['collection_date']` is often a database record-creation date, not a verified sampling
+  date. Treat SRA metadata labels — including the stated amplicon target — as unverified: they
+  are frequently wrong. get_dataset('study') gives today's `analysis_date`; judge any date
+  against it (a recent past date is normal, not "future").
+- A named test (Mantel, PERMANOVA, ...) must be the test you actually ran; don't upgrade a
+  plain correlation to a named test.
+- Sanity-check the data against the stated context in get_dataset('study'). Don't invent
+  effects the data doesn't support; equally, don't accept a label the data contradicts —
+  where they disagree, the contradiction is itself a grounded finding worth recording.
+
+Keep going until the agenda (including follow-ups) is worked through, then reply DONE."""
+
+
+RECONCILE_SYSTEM = """You are a skeptical verification auditor. You are given a CLAIM and the
+INDEPENDENT EVIDENCE that was re-executed from the raw data (computation results and data
+values). Decide whether the evidence genuinely supports the claim's quantitative content.
+
+- Judge only against the evidence shown — never from prior knowledge.
+- Allow equivalent representations: unit conversions (a fraction vs a percent), values that
+  are a simple derivation of the evidence (e.g. a difference or ratio), and ranges.
+- IGNORE tokens that are identifiers, not quantities (sample accessions like SRR38966955).
+- If the claim packs several numbers, it is SUPPORTED only if every quantitative number is
+  backed; if some are and some aren't, say PARTIAL and list which fail.
+- Default to UNSUPPORTED when the evidence does not clearly back a number. Be strict.
+
+Reply with exactly one line 'VERDICT: SUPPORTED|PARTIAL|UNSUPPORTED' then one sentence why."""
+
+
+WRITE_SYSTEM = """Scientific writing assistant for microbial ecology. Write a Results section
+using ONLY the verified claims provided — every number must come from a claim. Do not add
+findings not in the claims. Report quality caveats plainly and politely. Past tense,
+objective, no interpretation. Synthesize into flowing prose (not a bullet list). Reference
+Figure/Table where natural."""
+
+
+# ── Tool schemas (moved verbatim from the prototype) ──────────────────────────
+TOOLS = [
+    {"type": "function", "function": {
+        "name": "propose_agenda",
+        "description": ("FIRST STEP. Propose the analyses / hypothesis tests worth running on this "
+                        "amplicon dataset — the things a curious microbial ecologist would actually "
+                        "test. Be comprehensive and go beyond the obvious summary stats."),
+        "parameters": {"type": "object", "properties": {
+            "items": {"type": "array", "items": {"type": "object", "properties": {
+                "question": {"type": "string", "description": "the analysis/hypothesis, e.g. 'Do samples cluster in ordination, and which taxa drive the separation?'"},
+                "rationale": {"type": "string", "description": "why it matters ecologically"}},
+                "required": ["question"]}}},
+            "required": ["items"]}}},
+    {"type": "function", "function": {
+        "name": "get_agenda",
+        "description": "See the current agenda and each item's status (pending/in_progress/done).",
+        "parameters": {"type": "object", "properties": {}}}},
+    {"type": "function", "function": {
+        "name": "add_followup",
+        "description": ("Recurse: when a result is surprising or opens a deeper question, add a "
+                        "follow-up investigation (e.g. ordination shows structure → which taxa drive "
+                        "it → are they contaminants or real signal?). This is how you go deeper."),
+        "parameters": {"type": "object", "properties": {
+            "question": {"type": "string"}, "rationale": {"type": "string"}},
+            "required": ["question"]}}},
+    {"type": "function", "function": {
+        "name": "mark_done",
+        "description": "Mark the current investigation finished; move to the next agenda item.",
+        "parameters": {"type": "object", "properties": {}}}},
+    {"type": "function", "function": {
+        "name": "get_dataset",
+        "description": "Load a named summary dataset's contents (list_datasets to see names).",
+        "parameters": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}},
+    {"type": "function", "function": {
+        "name": "list_datasets",
+        "description": "List available summary datasets.",
+        "parameters": {"type": "object", "properties": {}}}},
+    {"type": "function", "function": {
+        "name": "run_analysis",
+        "description": ("Run Python to compute anything the summaries lack. In scope: `counts` "
+                        "(samples×ASV read-count DataFrame), `tax` (ASV×rank Domain..Genus — join to "
+                        "counts to work at taxon level or split Bacteria/Archaea vs Eukaryota), `meta` "
+                        "(per-sample metadata incl. library_name, collection_date, x/y). Helpers: np, "
+                        "pd, pdist, squareform, braycurtis, entropy, pearsonr, spearmanr, kruskal, "
+                        "mannwhitneyu, PCA. Code MUST assign to `result`. Compute before you claim."),
+        "parameters": {"type": "object", "properties": {
+            "label": {"type": "string"}, "code": {"type": "string", "description": "Python that sets `result`"}},
+            "required": ["label", "code"]}}},
+    {"type": "function", "function": {
+        "name": "record_claim",
+        "description": ("Record ONE verifiable claim from the current investigation. Cite antecedents "
+                        "(data paths and/or computation ids) so it can be re-checked. Prefer insight "
+                        "(patterns, relationships, anomalies) over restating summary numbers."),
+        "parameters": {"type": "object", "properties": {
+            "statement": {"type": "string"},
+            "value": {"type": "string", "description": "the exact supporting value"},
+            "antecedents": {"type": "array", "items": {"type": "string"}},
+            "kind": {"type": "string", "enum": ["observation", "pattern", "anomaly", "quality_caveat"]}},
+            "required": ["statement", "value", "antecedents"]}}},
+]
+
+
+# ── Pure helpers (moved verbatim from the prototype) ──────────────────────────
+def _norm_antecedents(x):
+    """Antecedents as a clean list of tokens. Some models (e.g. Sonnet) return the
+    array arg as a delimited STRING ('c2, c3; path') instead of a JSON list — split
+    it rather than iterating it character-by-character."""
+    if isinstance(x, list):
+        items = x
+    elif isinstance(x, str):
+        items = re.split(r"[;,]", x)
+    else:
+        items = []
+    return [t.strip() for t in items if t and t.strip()]
+
+
+def _nums(s):
+    """Every genuine quantity in a string. The lookbehind blocks numbers embedded in
+    an alphanumeric token — not just glued to a letter ('PC1') but mid-token digit
+    runs like 'SRR38966955' (block preceded-by letter/digit/dot) — so accession IDs
+    aren't mistaken for claimed values. Handles ranges ('19-98') and thousands commas."""
+    return [float(x.replace(",", ""))
+            for x in re.findall(r"(?<![A-Za-z0-9.])\d[\d,]*(?:\.\d+)?", str(s))]
+
+
+def _close(x, n):
+    return abs(x - n) < 0.05 * max(abs(n), 1)
+
+
+def _match_num(x, cands):
+    """How (if at all) claim number x is backed by the antecedent numbers `cands`.
+
+    Verification must re-derive x in its STATED representation, not demand a literal
+    match: a value can be the same truth in different units (fraction<->percent) or
+    a simple derivation of the inputs (difference, ratio). Pairwise derivation is
+    limited to small summary sources so it can't spuriously fire on big result sets.
+    """
+    for n in cands:
+        if _close(x, n):
+            return "direct"
+        if _close(x, n * 100):
+            return "x100"          # claim in %, source a fraction
+        if n and _close(x, n / 100):
+            return "/100"          # claim a fraction, source in %
+    if len(cands) <= 12:            # derived from a summary (e.g. 73 = 84 - 11)
+        for a in cands:
+            for b in cands:
+                if a is b:
+                    continue
+                for val, tag in ((a - b, "diff"), (a + b, "sum"),
+                                 (100 * a / b if b else None, "pct"),
+                                 (100 * (b - a) / b if b else None, "pct")):
+                    if val is not None and _close(x, val):
+                        return "derived:" + tag
+    return None
+
+
+def _flatten_numbers(v, acc):
+    if isinstance(v, bool):
+        return
+    if isinstance(v, (int, float)):
+        acc.append(float(v))
+    elif isinstance(v, dict):
+        for x in v.values():
+            _flatten_numbers(x, acc)
+    elif isinstance(v, (list, tuple)):
+        for x in v:
+            _flatten_numbers(x, acc)
+
+
+def _jsonify(v, depth=0):
+    """Shrink an arbitrary computation result to a JSON-safe, size-capped form
+    (lists→50, dict items→50, depth 4). numpy/pandas are handled lazily so this
+    module imports cleanly even where they are absent (they always are wherever a
+    real result is produced)."""
+    if depth > 4:
+        return str(v)
+    try:
+        import numpy as np
+        import pandas as pd
+    except ImportError:
+        np = pd = None
+    if np is not None and isinstance(v, (np.floating, np.integer)):
+        return round(float(v), 4)
+    if isinstance(v, float):
+        return round(v, 4)
+    if np is not None and isinstance(v, np.ndarray):
+        return _jsonify(v.tolist(), depth + 1)
+    if isinstance(v, dict):
+        return {str(k): _jsonify(x, depth + 1) for k, x in list(v.items())[:50]}
+    if isinstance(v, (list, tuple)):
+        return [_jsonify(x, depth + 1) for x in list(v)[:50]]
+    if pd is not None and isinstance(v, (pd.Series, pd.DataFrame)):
+        return _jsonify(v.to_dict(), depth + 1)
+    return v
+
+
+def build_dag(computations: dict, ledger: list) -> dict:
+    """Claim→antecedent provenance DAG. Nodes: computations (blue), claims
+    (verdict-coloured), and data paths (grey). Parameterised off the passed
+    state (was ``build_dag()`` over module globals in the prototype)."""
+    nodes, edges, seen = [], [], set()
+
+    def add(nid, **kw):
+        if nid not in seen:
+            seen.add(nid)
+            nodes.append({"id": nid, **kw})
+
+    for cid, comp in computations.items():
+        add(cid, type="computation", label=comp["label"])
+    for c in ledger:
+        add(c["id"], type="claim", label=c["statement"][:60], verdict=c.get("verdict"), kind=c["kind"])
+        for ant in c["antecedents"]:
+            if ant in computations:
+                edges.append({"from": ant, "to": c["id"]})
+            else:
+                add(ant, type="data", label=ant)
+                edges.append({"from": ant, "to": c["id"]})
+    return {"nodes": nodes, "edges": edges}
+
+
+def dag_mermaid(dag):
+    """Render a DAG dict as a Mermaid ```graph LR``` block (for the bench .md)."""
+    sty = {"verified": "fill:#2e7d32,color:#fff", "refuted": "fill:#c62828,color:#fff",
+           "unverifiable": "fill:#f9a825,color:#000", "computation": "fill:#1565c0,color:#fff",
+           "data": "fill:#455a64,color:#fff"}
+    lines = ["```mermaid", "graph LR"]
+    for n in dag["nodes"]:
+        lbl = n["label"].replace('"', "'")
+        shape = f'[["{lbl}"]]' if n["type"] == "computation" else (
+            f'("{lbl}")' if n["type"] == "data" else f'["{lbl}"]')
+        lines.append(f'  {n["id"]}{shape}')
+        cls = n.get("verdict") if n["type"] == "claim" else n["type"]
+        if cls in sty:
+            lines.append(f'  style {n["id"]} {sty[cls]}')
+    for e in dag["edges"]:
+        lines.append(f'  {e["from"]} --> {e["to"]}')
+    lines.append("```")
+    return "\n".join(lines)
+
+
+# ── Injection points ──────────────────────────────────────────────────────────
+@runtime_checkable
+class DataSource(Protocol):
+    """Reads the summary datasets and navigates data-path antecedents. Pure file
+    reads (kept synchronous); the same instance serves the agenda tools AND the
+    deterministic re-read half of ``verify()``."""
+
+    def read_json(self, name: str) -> Any | None:
+        """Read a viz JSON payload by base name (``counts``/``taxonomy``/``samples``/
+        ``provenance``/``renorm_stats``), trying ``.json`` then ``.json.gz``. None if absent."""
+        ...
+
+    def datasets(self) -> dict[str, Any]:
+        """The named summary datasets the agent can ``get_dataset``/``list_datasets``."""
+        ...
+
+    def navigate(self, path: str) -> tuple[bool, Any]:
+        """Resolve a dotted data-path antecedent against ``datasets()`` → (found, value)."""
+        ...
+
+    @property
+    def study(self) -> dict:
+        """Stated study/methods context (replaces the ``STUDY_GROUNDED`` global)."""
+        ...
+
+
+@runtime_checkable
+class CodeExecutor(Protocol):
+    """Runs model-written analysis code in an isolated jail and returns
+    ``(ok, result_or_error)``. The SAME call re-runs the stored code at verify
+    time, which is what makes computed claims deterministically re-derivable."""
+
+    async def run(self, code: str, timeout: int = 30) -> tuple[bool, Any]:
+        ...
+
+
+@dataclass
+class LLMClient:
+    """Thin async wrapper over an OpenAI-compatible chat endpoint, carrying the
+    default model. Tool-calling args (``tools``/``tool_choice``) pass straight
+    through, so the same client drives the agenda loop and the reconciler.
+
+    ``client`` must be an ``openai.AsyncOpenAI`` (or anything with the same
+    ``.chat.completions.create`` async coroutine)."""
+
+    client: Any
+    model: str
+
+    async def chat(self, messages, *, model: str | None = None, tools=None,
+                   tool_choice=None, temperature: float = 0.25, max_tokens: int = 2500):
+        """Return the raw completion (caller reads ``choices[0].message`` /
+        ``tool_calls``). Only non-None optional args are forwarded so a plain
+        completion and a tool-calling turn share one path."""
+        kwargs: dict[str, Any] = {
+            "model": model or self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if tools is not None:
+            kwargs["tools"] = tools
+        if tool_choice is not None:
+            kwargs["tool_choice"] = tool_choice
+        return await self.client.chat.completions.create(**kwargs)
+
+
+# ── Concrete DataSource ───────────────────────────────────────────────────────
+_UNASSIGNED = {"", "na", "unclassified", "unassigned", "incertae sedis", "none"}
+
+
+class DirDataSource:
+    """A ``DataSource`` backed by a directory of viz JSON files. Used by BOTH the
+    offline bench (over ``OMC_BENCH_DATA``) and the portal route (over the
+    squashfuse ``/viz/data`` mount) — the server-side re-read half of ``verify()``
+    reads the same bytes the in-container executor reads, preserving determinism.
+
+    ``study`` is the stated study/methods context; the prototype's
+    ``_build_datasets`` derived the ``study`` dataset from a ``STUDY_GROUNDED``
+    global plus the overview fixture — here both are passed in explicitly.
+    ``overview`` (the parse_microscape-shaped summary) is optional; when omitted a
+    minimal one is computed from the same viz JSON so the agent's ``get_dataset``
+    still returns a usable ``overview``/``taxonomy_summary``."""
+
+    def __init__(self, data_dir: Path | str, study: dict | None = None,
+                 overview: dict | None = None):
+        self.data_dir = Path(data_dir)
+        self._study_meta = study or {}
+        self._overview = overview
+        self._datasets: dict[str, Any] | None = None
+
+    # -- file reads -------------------------------------------------------------
+    def read_json(self, name: str) -> Any | None:
+        """Read ``{name}.json`` then ``{name}.json.gz`` from the data dir; None if absent."""
+        for p in (self.data_dir / f"{name}.json", self.data_dir / f"{name}.json.gz"):
+            if p.exists():
+                op = gzip.open if p.suffix == ".gz" else open
+                with op(p, "rt") as f:
+                    return json.load(f)
+        return None
+
+    # backwards-compatible private alias (prototype called this ``_rj``)
+    _rj = read_json
+
+    def _build_overview(self) -> dict:
+        """Compute a parse_microscape-shaped summary from the viz JSON when the
+        caller didn't supply one (mirrors the bench ``fixtures.build_pipeline_outputs``
+        shape closely enough for the agent's ``overview``/``taxonomy_summary``)."""
+        renorm = self.read_json("renorm_stats") or {}
+        samples = self.read_json("samples") or []
+        taxonomy = self.read_json("taxonomy") or {}
+        provenance = self.read_json("provenance") or {}
+
+        db_name, tax = next(iter(taxonomy.items()), ("none", {}))
+        levels = tax.get("levels", [])
+        assignments = tax.get("assignments", {})
+
+        def _clean(v):
+            return None if (v or "").strip().lower() in _UNASSIGNED else v
+
+        classified_per_rank = {}
+        for i, level in enumerate(levels):
+            classified_per_rank[level.lower()] = sum(
+                1 for a in assignments.values() if i < len(a) and _clean(a[i]) is not None)
+        phylum_idx = levels.index("Phylum") if "Phylum" in levels else 1
+        from collections import Counter
+        phyla = Counter(
+            v for a in assignments.values()
+            if phylum_idx < len(a) and (v := _clean(a[phylum_idx])) is not None)
+        top_phyla = dict(phyla.most_common(5))
+        prok = renorm.get("prokaryote", {})
+        return {
+            "asv_summary": {
+                "total_asvs": prok.get("n_asvs", len(assignments)),
+                "n_samples": prok.get("n_samples", len(samples)),
+                "samples": [s.get("id") for s in samples if isinstance(s, dict)],
+            },
+            "taxonomy_summary": {
+                "database": db_name,
+                "databases_used": [db_name],
+                "total_asvs_classified": len(assignments),
+                "classified_per_rank": classified_per_rank,
+                "top_phyla": top_phyla,
+                "phyla": top_phyla,
+            },
+        }
+
+    def datasets(self) -> dict[str, Any]:
+        """The named summary datasets (built once, cached). Ports the prototype's
+        ``_build_datasets`` off injected ``study``/``overview`` instead of globals."""
+        if self._datasets is not None:
+            return self._datasets
+        fx = self._overview if self._overview is not None else self._build_overview()
+        prov = self.read_json("provenance") or {}
+        samples = self.read_json("samples") or []
+        sg = self._study_meta or {}
+        self._datasets = {
+            "overview": fx,
+            # Stated study/methods context — the amplicon target here is the SRA metadata
+            # LABEL, which is frequently wrong; verify it against the observed taxonomy.
+            "study": {
+                # Today's real date — so the agent judges temporal plausibility correctly
+                # (a model with no clock can mistake a recent date for a future one).
+                "analysis_date": _datetime.date.today().isoformat(),
+                "stated_target_label": sg.get("title"),
+                "study_name": sg.get("study_name"),
+                "organism": sg.get("organism"),
+                "platform": sg.get("platform"),
+                "taxonomy_database": fx.get("taxonomy_summary", {}).get("database"),
+                "pipeline_stages": [s.get("id") for s in prov.get("stages", [])],
+                "caveat": ("stated_target_label is the SRA-metadata amplicon label and can be "
+                           "wrong (18S runs are commonly mislabeled '16S'); confirm against tax Domain."),
+            },
+            "renorm_stats": self.read_json("renorm_stats") or fx.get("renorm", {}),
+            "provenance": {"total": prov.get("total", {}),
+                           "stages": [s.get("id") for s in prov.get("stages", [])],
+                           "n_samples": len(prov.get("samples", {}))},
+            "samples": {"n": len(samples),
+                        "total_reads": sum(s.get("total_reads", 0) for s in samples if isinstance(s, dict))},
+            "taxonomy_summary": fx.get("taxonomy_summary", {}),
+        }
+        return self._datasets
+
+    def navigate(self, path: str) -> tuple[bool, Any]:
+        """Resolve a dotted path (``a.b.0.c``) against ``datasets()``. Ports the
+        prototype's ``_navigate``; used by both ``verify()`` and the DAG viewer."""
+        cur: Any = self.datasets()
+        for part in path.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            elif isinstance(cur, list) and part.lstrip("-").isdigit() and int(part) < len(cur):
+                cur = cur[int(part)]
+            else:
+                return False, None
+        return True, cur
+
+    @property
+    def study(self) -> dict:
+        return self._study_meta
+
+
+# ── DEV/offline executor: resource-limited subprocess ─────────────────────────
+# Ported verbatim from the prototype ``_CHILD_RUNNER``. In production the agent's
+# analysis runs inside the omc-session container (see portal/app/autoresearch_executor.py);
+# THIS approximates that jail with a separate python process (CPU+memory rlimits,
+# network cut after trusted imports). Data is read from EXPLORER_DATA_DIR inside the
+# child, so the same code re-runs deterministically at verification time.
+_SUBPROCESS_RUNNER = r'''
+import os, sys, json, gzip, resource
+resource.setrlimit(resource.RLIMIT_CPU, (25, 25))          # ~25s CPU
+try:  # generous virtual-address cap — numpy/BLAS reserve a lot even when RSS is small
+    resource.setrlimit(resource.RLIMIT_AS, (8 * 1024**3, 8 * 1024**3))
+except (ValueError, OSError):
+    pass
+DATA = os.environ["EXPLORER_DATA_DIR"]
+def _rj(name):
+    for p in (os.path.join(DATA, name + ".json"), os.path.join(DATA, name + ".json.gz")):
+        if os.path.exists(p):
+            op = gzip.open if p.endswith(".gz") else open
+            with op(p, "rt") as f:
+                return json.load(f)
+    return None
+# Trusted imports FIRST (ssl, loaded transitively, subclasses socket.socket) —
+# only after they're loaded do we disable the network for the model's code.
+import numpy as np, pandas as pd
+from scipy.spatial.distance import pdist, squareform, braycurtis
+from scipy.stats import entropy, pearsonr, spearmanr, kruskal, mannwhitneyu
+from sklearn.decomposition import PCA
+_c = _rj("counts"); counts = None
+if _c:
+    _m = np.zeros((len(_c["samples"]), len(_c["asvs"])))
+    for _s, _a, _n, _r in _c["data"]:
+        _m[_s, _a] = _n
+    counts = pd.DataFrame(_m, index=_c["samples"], columns=_c["asvs"])
+_t = _rj("taxonomy") or {}
+_db, _body = next(iter(_t.items()), ("none", {}))
+_lv = _body.get("levels", [])
+tax = pd.DataFrame.from_dict({a: dict(zip(_lv, l)) for a, l in _body.get("assignments", {}).items()},
+                            orient="index").reindex(columns=_lv)
+meta = pd.DataFrame(_rj("samples") or [])
+meta = meta.set_index("id") if "id" in meta.columns else meta
+import socket
+def _no_net(*a, **k):
+    raise OSError("network disabled in analysis sandbox")
+socket.socket = _no_net; socket.create_connection = _no_net; socket.getaddrinfo = _no_net
+def _j(v, d=0):
+    if d > 4: return str(v)
+    if isinstance(v, (np.floating, np.integer)): return round(float(v), 4)
+    if isinstance(v, float): return round(v, 4)
+    if isinstance(v, np.ndarray): return _j(v.tolist(), d + 1)
+    if isinstance(v, dict): return {str(k): _j(x, d + 1) for k, x in list(v.items())[:50]}
+    if isinstance(v, (list, tuple)): return [_j(x, d + 1) for x in list(v)[:50]]
+    if isinstance(v, (pd.Series, pd.DataFrame)): return _j(v.to_dict(), d + 1)
+    return v
+_ns = dict(np=np, pd=pd, counts=counts, tax=tax, meta=meta, pdist=pdist, squareform=squareform,
+           braycurtis=braycurtis, entropy=entropy, pearsonr=pearsonr, spearmanr=spearmanr,
+           kruskal=kruskal, mannwhitneyu=mannwhitneyu, PCA=PCA)
+try:
+    exec(sys.stdin.read(), _ns)
+    print(json.dumps({"__ok__": _j(_ns["result"])} if "result" in _ns
+                     else {"__err__": "code did not set a `result` variable"}))
+except Exception as e:
+    print(json.dumps({"__err__": f"{type(e).__name__}: {e}"}))
+'''
+
+
+class SubprocessExecutor:
+    """DEV/offline ``CodeExecutor``: runs model code in a resource-limited child
+    process reading from ``data_dir``. This is the stand-in the isolated session
+    container replaces in production (``ContainerExecutor``)."""
+
+    def __init__(self, data_dir: Path | str):
+        self.data_dir = Path(data_dir)
+
+    def _run_sync(self, code: str, timeout: int) -> tuple[bool, Any]:
+        try:
+            p = subprocess.run(
+                [sys.executable, "-c", _SUBPROCESS_RUNNER], input=code, text=True,
+                capture_output=True, timeout=timeout,
+                env={**os.environ, "EXPLORER_DATA_DIR": str(self.data_dir),
+                     # single-threaded BLAS: deterministic + far smaller virtual footprint
+                     "OMP_NUM_THREADS": "1", "OPENBLAS_NUM_THREADS": "1", "MKL_NUM_THREADS": "1"},
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"timeout >{timeout}s"
+        lines = (p.stdout or "").strip().splitlines()
+        try:
+            r = json.loads(lines[-1]) if lines else {}
+        except json.JSONDecodeError:
+            return False, ((p.stderr or p.stdout or "no output").strip().splitlines() or ["error"])[-1][:200]
+        return (True, r["__ok__"]) if "__ok__" in r else (False, r.get("__err__", "error"))
+
+    async def run(self, code: str, timeout: int = 30) -> tuple[bool, Any]:
+        """Async facade over the blocking subprocess call (off the event loop)."""
+        return await asyncio.to_thread(self._run_sync, code, timeout)
+
+
+# ── Orchestrator ──────────────────────────────────────────────────────────────
+class Autoresearcher:
+    """Drives one claim-grounded autoresearch run over one submission's data.
+
+    All state is per-instance (``computations``/``ledger``/``agenda``) so two runs
+    never share globals. Construct with an injected ``DataSource`` (reads),
+    ``LLMClient`` (tool-calling), and ``CodeExecutor`` (jail), then::
+
+        completed = await ar.explore()
+        await ar.verify()
+        snap = ar.snapshot(resolve=True)
+        prose = await ar.write_results()
+
+    ``on_progress(event, detail)`` — if given — is awaited on each tool call and
+    verification event so a route can stream SSE.
+    """
+
+    def __init__(self, data: DataSource, llm: LLMClient, executor: CodeExecutor, *,
+                 explore_model: str | None = None, verify_model: str | None = None,
+                 max_steps: int = 48, max_followups: int = 12,
+                 reconcile: bool = True,
+                 on_progress: Optional[Callable[[str, Any], Awaitable]] = None):
+        self.data = data
+        self.llm = llm
+        self.executor = executor
+        self.explore_model = explore_model or llm.model
+        self.verify_model = verify_model or llm.model
+        self.max_steps = max_steps
+        self.max_followups = max_followups
+        self.reconcile = reconcile
+        self.on_progress = on_progress
+        # per-run state (was module globals in the prototype)
+        self.computations: dict[str, Any] = {}   # cid -> {label, code, result}
+        self.ledger: list[dict] = []              # claim dicts
+        self.agenda: list[dict] = []              # {id, question, rationale, status, parent}
+        self.results_prose: str | None = None     # last write_results() output (for snapshot)
+
+    # -- progress ---------------------------------------------------------------
+    async def _emit(self, event: str, detail: Any) -> None:
+        if self.on_progress is not None:
+            await self.on_progress(event, detail)
+
+    # -- agenda helpers ---------------------------------------------------------
+    def _current_investigation(self) -> str | None:
+        """The investigation being worked (first in-progress, else first pending)."""
+        for st in ("in_progress", "pending"):
+            for a in self.agenda:
+                if a["status"] == st:
+                    return a["id"]
+        return None
+
+    # -- tool dispatch ----------------------------------------------------------
+    async def _exec_tool(self, name: str, args: dict) -> dict:
+        """Execute one agent tool call against instance state (was ``_exec_tool``)."""
+        if name == "propose_agenda":
+            for it in args.get("items", [])[:20]:
+                self.agenda.append({"id": f"a{len(self.agenda) + 1}", "question": it.get("question", ""),
+                                    "rationale": it.get("rationale", ""), "status": "pending", "parent": None})
+            if self.agenda:
+                self.agenda[0]["status"] = "in_progress"
+            return {"agenda": [{"id": a["id"], "question": a["question"], "status": a["status"]} for a in self.agenda]}
+        if name == "get_agenda":
+            return {"agenda": [{"id": a["id"], "question": a["question"], "status": a["status"],
+                                "parent": a["parent"]} for a in self.agenda]}
+        if name == "add_followup":
+            # Cap follow-ups so a recursive model can't grow the agenda unboundedly.
+            n_followups = sum(1 for a in self.agenda if a["parent"])
+            if n_followups >= self.max_followups:
+                return {"added": None, "note": f"follow-up cap reached ({self.max_followups}); "
+                        "finish the current agenda instead of adding more."}
+            parent = self._current_investigation()
+            self.agenda.append({"id": f"a{len(self.agenda) + 1}", "question": args.get("question", ""),
+                                "rationale": args.get("rationale", ""), "status": "pending", "parent": parent})
+            return {"added": self.agenda[-1]["id"], "parent": parent,
+                    "pending": sum(a["status"] == "pending" for a in self.agenda)}
+        if name == "mark_done":
+            cur = self._current_investigation()
+            for a in self.agenda:
+                if a["id"] == cur:
+                    a["status"] = "done"
+            nxt = self._current_investigation()
+            for a in self.agenda:
+                if a["id"] == nxt and a["status"] == "pending":
+                    a["status"] = "in_progress"
+            pend = sum(a["status"] in ("pending", "in_progress") for a in self.agenda)
+            return {"done": cur, "now": nxt, "remaining": pend}
+        if name == "list_datasets":
+            return {"datasets": list(self.data.datasets()),
+                    "note": "use run_analysis with `counts`/`tax`/`meta` for real tests"}
+        if name == "get_dataset":
+            d = self.data.datasets().get(args.get("name"))
+            return d if d is not None else {"error": "unknown", "available": list(self.data.datasets())}
+        if name == "run_analysis":
+            ok, res = await self.executor.run(args.get("code", ""))
+            if not ok:
+                return {"ok": False, "error": res}
+            cid = f"c{len(self.computations) + 1}"
+            self.computations[cid] = {"label": args.get("label", cid),
+                                      "code": args.get("code", ""), "result": res}
+            return {"ok": True, "computation_id": cid, "result": res}
+        if name == "record_claim":
+            claim = {"id": f"k{len(self.ledger) + 1}", "statement": args.get("statement", ""),
+                     "value": str(args.get("value", "")),
+                     "antecedents": _norm_antecedents(args.get("antecedents")),
+                     "kind": args.get("kind", "observation"),
+                     "investigation": self._current_investigation()}
+            self.ledger.append(claim)
+            return {"recorded": True, "claim_id": claim["id"], "n_claims": len(self.ledger)}
+        return {"error": f"unknown tool {name}"}
+
+    # -- explore ----------------------------------------------------------------
+    async def explore(self) -> bool:
+        """Run the agenda-driven tool-calling loop. Returns True only when the
+        agenda (including follow-ups) was actually worked through; on a step-cap
+        exit the in-progress item is marked ``interrupted`` (never faked done)."""
+        messages = [
+            {"role": "system", "content": EXPLORE_SYSTEM},
+            {"role": "user", "content": "Propose your agenda of microbial-ecology tests, "
+             "then work through it, recursing where it gets interesting."}]
+        for step in range(self.max_steps):
+            r = await self.llm.chat(messages, model=self.explore_model, tools=TOOLS,
+                                    tool_choice="auto", temperature=0.25, max_tokens=2500)
+            msg = r.choices[0].message
+            if not msg.tool_calls:
+                content = _strip_think(msg.content or "")
+                active = [a for a in self.agenda if a["status"] in ("pending", "in_progress")]
+                if "DONE" in content.upper() and not active:
+                    break
+                if "DONE" in content.upper() and active:
+                    messages.append({"role": "user",
+                                     "content": f"{len(active)} agenda items remain — work the next one (get_agenda)."})
+                    continue
+                messages.append({"role": "user",
+                                 "content": "Continue with the current investigation, or mark_done and take the next."})
+                continue
+            messages.append({"role": "assistant", "content": msg.content or "",
+                             "tool_calls": [tc.model_dump() for tc in msg.tool_calls]})
+            for tc in msg.tool_calls:
+                try:
+                    args = json.loads(tc.function.arguments or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                result = await self._exec_tool(tc.function.name, args)
+                label = (args.get("label") or args.get("name") or args.get("question")
+                         or (args.get("statement") or "")[:40])
+                await self._emit(tc.function.name, {"step": step, "label": str(label)[:80],
+                                                    "result": result})
+                messages.append({"role": "tool", "tool_call_id": tc.id,
+                                 "content": json.dumps(result, default=str)[:3500]})
+        # Step cap hit with work outstanding: the current item was interrupted, and
+        # pending items stay pending. Return True only when nothing is outstanding.
+        for a in self.agenda:
+            if a["status"] == "in_progress":
+                a["status"] = "interrupted"
+        return not any(a["status"] in ("pending", "in_progress", "interrupted") for a in self.agenda)
+
+    # -- verify -----------------------------------------------------------------
+    def _evidence_for(self, claim, comp_cache: dict) -> str:
+        """Deterministic evidence block for a claim: re-executed computation results
+        (from ``comp_cache``) and re-read data values. This is what the reconciler
+        judges against — not memory."""
+        parts = []
+        for ant in claim["antecedents"]:
+            if ant in self.computations:
+                good, res = comp_cache.get(ant, (False, None))
+                parts.append(f"[{ant}] {self.computations[ant]['label']} (re-executed) = "
+                             + (json.dumps(res, default=str)[:600] if good else "ERROR"))
+            else:
+                found, val = self.data.navigate(ant)
+                parts.append(f"[{ant}] = {json.dumps(val, default=str)[:300] if found else 'NOT FOUND'}")
+        return "\n".join(parts)
+
+    async def _reconcile_claim(self, claim, comp_cache: dict) -> dict:
+        """Model adjudication of a claim against its re-executed evidence. Only
+        invoked on a deterministic miss. Returns ``{verdict, reasoning}``."""
+        user = (f"CLAIM: {claim['statement']}\nCLAIMED VALUE: {claim['value']}\n\n"
+                f"INDEPENDENT EVIDENCE (re-executed from raw data):\n{self._evidence_for(claim, comp_cache)}")
+        resp = await self.llm.chat(
+            [{"role": "system", "content": RECONCILE_SYSTEM}, {"role": "user", "content": user}],
+            model=self.verify_model, max_tokens=4000, temperature=0.0)
+        text = _strip_think(resp.choices[0].message.content or "")
+        m = re.search(r"VERDICT:\s*(SUPPORTED|PARTIAL|UNSUPPORTED)", text.upper())
+        return {"verdict": m.group(1).lower() if m else "unsupported", "reasoning": text.strip()[:400]}
+
+    async def verify(self) -> None:
+        """Re-derive each claim from its antecedents (data re-read; computations
+        re-EXECUTED via the same executor). Deterministic first; a true claim is
+        never marked refuted for a representation mismatch. When ``reconcile`` is on,
+        a deterministic MISS escalates to a skeptical model reconciliation against
+        the SAME re-executed evidence — labelled so judgment-backed claims are visible.
+
+        Each distinct computation is re-executed AT MOST ONCE per ``verify()`` call
+        (cached) — the deterministic pass and any reconciliation share the result,
+        which also bounds ``docker exec`` load in the container backend."""
+        comp_cache: dict[str, tuple[bool, Any]] = {}
+
+        async def _rerun(cid: str) -> tuple[bool, Any]:
+            if cid not in comp_cache:
+                comp_cache[cid] = await self.executor.run(self.computations[cid]["code"])
+            return comp_cache[cid]
+
+        for c in self.ledger:
+            c["antecedents"] = _norm_antecedents(c["antecedents"])  # tolerate string-form ledgers
+            claim_nums = _nums(c["value"])
+            candidates: list[float] = []
+            strvals: list[str] = []
+            checked: list[str] = []
+            for ant in c["antecedents"]:
+                if ant in self.computations:
+                    good, res = await _rerun(ant)  # re-execute stored code (cached)
+                    if good:
+                        _flatten_numbers(res, candidates)
+                    checked.append(f"{ant}:{'run' if good else 'err'}")
+                else:  # data path
+                    found, actual = self.data.navigate(ant)
+                    if found:
+                        _flatten_numbers(actual, candidates)
+                        strvals.append(str(actual))
+                    checked.append(f"{ant}:{'ok' if found else 'nopath'}")
+
+            have_evidence = bool(candidates or strvals)
+            if claim_nums:
+                methods = [_match_num(x, candidates) for x in claim_nums]
+                ok = all(methods) if candidates else None
+                c["method"] = ",".join(m for m in methods if m) or None
+            else:  # non-numeric claim (e.g. a database name)
+                ok = any(c["value"].strip().lower() in s.lower() for s in strvals) if strvals else None
+            c["verdict"] = "verified" if ok else ("unverifiable" if (ok is None or not have_evidence) else "refuted")
+            c["checked"] = checked
+            # Escalate deterministic misses to a skeptical model reconciliation against
+            # the SAME re-executed evidence (labelled, so judgment-backed claims are visible).
+            if c["verdict"] != "verified" and self.reconcile and have_evidence:
+                rec = await self._reconcile_claim(c, comp_cache)
+                c["reconcile"] = rec
+                if rec["verdict"] == "supported":
+                    c["verdict"], c["method"] = "verified", "reconciled"
+
+    # -- DAG --------------------------------------------------------------------
+    def build_dag(self) -> dict:
+        """The claim→antecedent provenance DAG for this run's current state."""
+        return build_dag(self.computations, self.ledger)
+
+    # -- write ------------------------------------------------------------------
+    async def write_results(self, verified: list[dict] | None = None) -> str:
+        """Write the Results prose from VERIFIED claims only (WRITE_SYSTEM). When
+        ``verified`` is omitted, uses this run's verified claims. The result is
+        cached on ``self.results_prose`` so a subsequent ``snapshot()`` includes it."""
+        if verified is None:
+            verified = [c for c in self.ledger if c.get("verdict") == "verified"]
+        claims_txt = "\n".join(
+            f"- [{c['kind']}] {c['statement']} (value={c['value']})" for c in verified)
+        sg = self.data.study or {}
+        study = (f"Study: {sg.get('title', '(unknown)')} — {sg.get('study_name', '')} "
+                 f"({sg.get('bioproject', '')}), {sg.get('platform', '')}.")
+        msgs = [{"role": "system", "content": WRITE_SYSTEM},
+                {"role": "user", "content": f"{study}\n\nVERIFIED CLAIMS:\n{claims_txt}\n\n"
+                 "Write the Results section."}]
+        content = ""
+        for mt in (6000, 12000):
+            r = await self.llm.chat(msgs, model=self.explore_model, temperature=0.4, max_tokens=mt)
+            content = _strip_think(r.choices[0].message.content or "")
+            if content.strip():
+                break
+        self.results_prose = content
+        return content
+
+    # -- run summary ------------------------------------------------------------
+    def run_summary(self, completed: bool | None = None) -> dict:
+        """The ``run`` block (completed + investigation counts) for the snapshot/ledger."""
+        done = sum(a["status"] == "done" for a in self.agenda)
+        if completed is None:
+            completed = bool(self.agenda) and all(a["status"] == "done" for a in self.agenda)
+        return {"completed": completed, "investigations_done": done,
+                "investigations_total": len(self.agenda)}
+
+    # -- snapshot ---------------------------------------------------------------
+    def snapshot(self, resolve: bool = True, completed: bool | None = None,
+                 results_prose: str | None = None) -> dict:
+        """One self-contained snapshot of this run: claims, computations, agenda,
+        DAG, run summary, and (optionally) the Results prose. With ``resolve=True``
+        every antecedent is pre-baked to ``{ant, code?, result?, value?}`` so the
+        provenance viewer template never re-reads data (mirrors the bench
+        ``build_dag_artifact.resolve()`` step). Schema is the frozen contract shared
+        with the portal route + provenance template. ``results_prose`` defaults to the
+        last ``write_results()`` output (call it before ``snapshot`` to include prose)."""
+        if results_prose is None:
+            results_prose = self.results_prose
+        def _resolve(ant: str) -> dict:
+            if ant in self.computations:
+                c = self.computations[ant]
+                return {"ant": ant, "code": c["code"],
+                        "result": json.dumps(c["result"], default=str)[:1200]}
+            found, val = self.data.navigate(ant)
+            return {"ant": ant, "value": (json.dumps(val, default=str)[:300] if found else "—")}
+
+        claims = []
+        for c in self.ledger:
+            entry = {
+                "id": c["id"], "statement": c["statement"], "value": c["value"],
+                "verdict": c.get("verdict", "unverifiable"), "kind": c.get("kind", "observation"),
+                "method": c.get("method"), "antecedents": c["antecedents"],
+            }
+            if c.get("reconcile"):
+                entry["reconcile"] = c["reconcile"]
+            if resolve:
+                entry["resolved"] = [_resolve(a) for a in c["antecedents"]]
+            claims.append(entry)
+        return {
+            "claims": claims,
+            "computations": self.computations,
+            "agenda": self.agenda,
+            "dag": self.build_dag(),
+            "results_prose": results_prose,
+            "run": self.run_summary(completed),
+        }
+
+    @classmethod
+    def from_snapshot(cls, snap: dict, data: DataSource, llm: LLMClient,
+                      executor: CodeExecutor, **kw) -> "Autoresearcher":
+        """Reconstruct a researcher from a saved snapshot / ledger dict (keys
+        ``claims``/``computations``/``agenda``) for re-verification. Accepts both a
+        full ``snapshot()`` and the bench ``claims_ledger.json`` shape."""
+        ar = cls(data, llm, executor, **kw)
+        ar.ledger = list(snap.get("claims", []))
+        ar.computations = dict(snap.get("computations", {}))
+        ar.agenda = list(snap.get("agenda", []))
+        return ar
+
+
+# ── local think-stripper (avoids importing ai.llm_client's sync-only helpers) ─
+_THINK_CLOSED_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+_THINK_OPEN_RE = re.compile(r"<think>.*", re.DOTALL)
+
+
+def _strip_think(text: str) -> str:
+    """Strip ``<think>...</think>`` reasoning blocks (closed or truncated) from
+    model output. Mirrors ``ai.llm_client._strip_think`` but kept local so this
+    core has no dependency on the sync client module."""
+    if not text:
+        return ""
+    return _THINK_OPEN_RE.sub("", _THINK_CLOSED_RE.sub("", text)).strip()

--- a/ai/autoresearch.py
+++ b/ai/autoresearch.py
@@ -330,7 +330,7 @@ class DataSource(Protocol):
 
 @runtime_checkable
 class CodeExecutor(Protocol):
-    """Runs model-written analysis code in an isolated jail and returns
+    """Runs model-written analysis code in an isolated sandbox and returns
     ``(ok, result_or_error)``. The SAME call re-runs the stored code at verify
     time, which is what makes computed claims deterministically re-derivable."""
 
@@ -505,7 +505,7 @@ class DirDataSource:
 # ── DEV/offline executor: resource-limited subprocess ─────────────────────────
 # Ported verbatim from the prototype ``_CHILD_RUNNER``. In production the agent's
 # analysis runs inside the omc-session container (see portal/app/autoresearch_executor.py);
-# THIS approximates that jail with a separate python process (CPU+memory rlimits,
+# THIS approximates that sandbox with a separate python process (CPU+memory rlimits,
 # network cut after trusted imports). Data is read from EXPLORER_DATA_DIR inside the
 # child, so the same code re-runs deterministically at verification time.
 _SUBPROCESS_RUNNER = r'''
@@ -604,7 +604,7 @@ class Autoresearcher:
 
     All state is per-instance (``computations``/``ledger``/``agenda``) so two runs
     never share globals. Construct with an injected ``DataSource`` (reads),
-    ``LLMClient`` (tool-calling), and ``CodeExecutor`` (jail), then::
+    ``LLMClient`` (tool-calling), and ``CodeExecutor`` (sandbox), then::
 
         completed = await ar.explore()
         await ar.verify()

--- a/portal/app/autoresearch.py
+++ b/portal/app/autoresearch.py
@@ -13,7 +13,7 @@ but respects the HARD CONSTRAINTS of #29:
   * the agent's tool-calling loop runs server-side here (it orchestrates only — it
     never runs model code on the portal host);
   * model-written ``run_analysis`` code runs inside the isolated ``omc-session``
-    container via ``ContainerExecutor`` (``docker exec`` into the jail);
+    container via ``ContainerExecutor`` (``docker exec`` into the sandbox);
   * the deterministic re-read half of ``verify()`` uses a ``DirDataSource`` over the
     SAME squashfuse ``.sqsh`` mount the container reads, preserving determinism;
   * the LLM is acquired only through ``resolve_llm`` (no hardcoded endpoint).
@@ -73,7 +73,7 @@ def _dir_has_content(path) -> bool:
 
 async def ensure_session_running(slug: str, metadata: dict, user_id: int | None):
     """Guarantee the ``omc-session-{slug}`` container is up before the executor is
-    built — the HARD CONSTRAINT that model code runs in the jail, never on the host.
+    built — the HARD CONSTRAINT that model code runs in the sandbox, never on the host.
 
     Delegates to ``sessions.launch_session``, which is idempotent: it returns the
     live container if one is already running, resumes a stopped one, and relaunches
@@ -188,7 +188,7 @@ async def run_autoresearch_stream(
 
         async def run():
             try:
-                # 1. Session container must be running — model code runs in the jail.
+                # 1. Session container must be running — model code runs in the sandbox.
                 await progress_queue.put({"event": "session", "detail": "starting session container"})
                 try:
                     await ensure_session_running(sub_slug, session_metadata, user_id)
@@ -198,7 +198,7 @@ async def run_autoresearch_stream(
                     return
                 await progress_queue.put({"event": "session", "detail": "container ready"})
 
-                # 2. Data source (server-side re-reads) + container executor (jail).
+                # 2. Data source (server-side re-reads) + container executor (sandbox).
                 data = await _build_data_source(sub_slug, sub_study_meta)
                 # Pre-warm the cached datasets off the event loop — the first read
                 # parses renorm/samples/taxonomy/provenance JSON and would otherwise

--- a/portal/app/autoresearch.py
+++ b/portal/app/autoresearch.py
@@ -1,0 +1,355 @@
+"""Claim-grounded autoresearch endpoints (issue #29).
+
+Drives the reusable ``ai.autoresearch`` core from the website. An author triggers
+an autonomous analysis run over their submission's pipeline data; the agent
+proposes an agenda, runs its own analysis code, records verifiable claims, then a
+two-layer verification (deterministic re-execution + skeptical reconciliation)
+grades each claim before the Results prose is written from the verified ones.
+
+This mirrors ``reviews.py`` (background work, SSE progress, ``resolve_llm`` for the
+backend, persistence to ``Submission.interview_data``, optional ``.omc/`` commit),
+but respects the HARD CONSTRAINTS of #29:
+
+  * the agent's tool-calling loop runs server-side here (it orchestrates only — it
+    never runs model code on the portal host);
+  * model-written ``run_analysis`` code runs inside the isolated ``omc-session``
+    container via ``ContainerExecutor`` (``docker exec`` into the jail);
+  * the deterministic re-read half of ``verify()`` uses a ``DirDataSource`` over the
+    SAME squashfuse ``.sqsh`` mount the container reads, preserving determinism;
+  * the LLM is acquired only through ``resolve_llm`` (no hardcoded endpoint).
+
+Routes:
+  * ``POST /autoresearch/{slug}/run-stream`` — SSE run + persistence + optional PR.
+  * ``GET  /autoresearch/{slug}/provenance`` — the provenance DAG viewer.
+"""
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse, RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import attributes
+from sqlalchemy import select
+
+from .config import get_settings
+from .database import get_db, async_session, Submission, User
+from .auth import require_user, get_current_user
+from .templating import templates
+
+router = APIRouter(prefix="/autoresearch", tags=["autoresearch"])
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+
+# ── helpers (mirrors reviews.py) ──────────────────────────────────────────────
+async def _get_llm_config(user_id: int) -> dict:
+    """Resolve the LLM config for a user's chosen backend (local / shared-admin /
+    personal OpenRouter), honouring the explicit /settings choice via
+    ``llm_backends.resolve_llm``. Copied from ``reviews.py`` so the two generation
+    surfaces route the LLM identically."""
+    from sqlalchemy import select as _select
+    from .database import User as _User
+    from .llm_backends import resolve_llm
+    from .database import async_session as _session
+    async with _session() as _db:
+        target = (await _db.execute(_select(_User).where(_User.id == user_id))).scalar_one_or_none()
+    return await resolve_llm(target)
+
+
+def _dir_has_content(path) -> bool:
+    """True when ``path`` exists and is a non-empty directory (not just an empty
+    mountpoint). Copied from ``reviews.py``."""
+    p = Path(path)
+    if not p.exists():
+        return False
+    try:
+        return any(p.iterdir())
+    except OSError:
+        return False
+
+
+async def ensure_session_running(slug: str, metadata: dict, user_id: int | None):
+    """Guarantee the ``omc-session-{slug}`` container is up before the executor is
+    built — the HARD CONSTRAINT that model code runs in the jail, never on the host.
+
+    Delegates to ``sessions.launch_session``, which is idempotent: it returns the
+    live container if one is already running, resumes a stopped one, and relaunches
+    a dead/orphaned one. A short readiness wait mirrors ``resume_session``'s ~3s
+    grace for the container's processes (and the ``/data`` mount) to come up before
+    the first ``docker exec``. Raises on failure so the caller can emit a clean
+    ``error`` event."""
+    from .sessions import launch_session
+    session = await launch_session(slug, metadata, user_id=user_id)
+    await asyncio.sleep(3)  # let container processes + /data mount settle
+    return session
+
+
+async def _build_data_source(slug: str, study: dict):
+    """Build a ``DirDataSource`` over the submission's viz JSON — the server-side
+    reads for the agenda tools AND the deterministic re-read half of ``verify()``.
+
+    Points at the host squashfuse mount of ``{slug}.sqsh`` (the SAME ``.sqsh``
+    bind-mounted read-only into the container at ``/data``), so server-side
+    ``navigate`` and in-container re-execution see identical bytes. Mirrors the
+    mount/fallback handling in ``reviews.py`` (best-effort mount, ``_dir_has_content``
+    guard, fall back to ``local_download_path/{slug}``)."""
+    from .staging import get_results_path
+    from .sessions import _sqsh_mount, SQSH_MOUNT_BASE
+    from ai.autoresearch import DirDataSource
+
+    sqsh_mount = SQSH_MOUNT_BASE / slug
+    sqsh_path = get_results_path(slug)
+    if sqsh_path and not _dir_has_content(sqsh_mount):
+        try:
+            sqsh_mount = await _sqsh_mount(slug, sqsh_path)
+        except Exception as e:
+            logger.warning(f"Could not mount sqsh for {slug}: {e}")
+
+    viz_dir = None
+    for base in (sqsh_mount, Path(settings.local_download_path) / slug):
+        cand = Path(base) / "viz" / "data"
+        if _dir_has_content(cand):
+            viz_dir = cand
+            break
+    if viz_dir is None:
+        raise RuntimeError(
+            "No pipeline viz data found (expected .../viz/data) — autoresearch "
+            "requires completed pipeline results (.sqsh) for this submission.")
+    return DirDataSource(viz_dir, study=study)
+
+
+# ── run (SSE) ─────────────────────────────────────────────────────────────────
+@router.post("/{slug}/run-stream")
+async def run_autoresearch_stream(
+    slug: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Run claim-grounded autoresearch with SSE progress streaming.
+
+    Clone of ``reviews.generate_manuscript_stream``: snapshot the submission fields
+    to locals, resolve the LLM, ensure the session container is running, mount the
+    data, then drive ``Autoresearcher.explore()`` → ``verify()`` → ``write_results()``
+    on a background task while forwarding tool-call / verification events over SSE.
+    On completion the resolved snapshot is persisted to
+    ``interview_data['_autoresearch']`` in a fresh DB session and (optionally) the
+    Results prose is committed to the paper repo's ``.omc/`` via a PR."""
+    if not settings.autoresearch_enabled:
+        raise HTTPException(status_code=403, detail="Autoresearch is not enabled.")
+
+    stmt = select(Submission).where(
+        Submission.slug == slug,
+        Submission.user_id == user.id,
+    )
+    result = await db.execute(stmt)
+    submission = result.scalar_one_or_none()
+    if not submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    # Snapshot submission fields to locals before we leave the db-session scope.
+    sub_slug = submission.slug
+    sub_id = submission.id
+    sub_accession = submission.bioproject_accession
+    sub_pipeline = submission.pipeline.value
+    sub_title = submission.title or ""
+    sub_study_meta = dict(submission.sample_metadata or {})
+    sub_interview = dict(submission.interview_data or {})
+    sub_github_repo = submission.github_repo
+    sub_selected_runs = submission.selected_runs or []
+
+    # Metadata written to the container at launch (same shape as sessions.launch).
+    session_metadata = {
+        "slug": sub_slug,
+        "accession": sub_accession,
+        "pipeline": sub_pipeline,
+        "title": sub_title,
+        "sample_metadata": sub_study_meta,
+        "interview_data": sub_interview,
+        "selected_runs": sub_selected_runs,
+    }
+
+    llm = await _get_llm_config(user.id)
+    user_id = user.id
+
+    result_holder: dict = {}
+
+    async def event_stream():
+        from openai import AsyncOpenAI
+        from ai.autoresearch import Autoresearcher, LLMClient
+
+        progress_queue: asyncio.Queue = asyncio.Queue()
+        await progress_queue.put({"event": "start", "detail": f"Using {llm['label']}"})
+
+        async def on_progress(event, detail):
+            await progress_queue.put({"event": event, "detail": detail})
+
+        async def run():
+            try:
+                # 1. Session container must be running — model code runs in the jail.
+                await progress_queue.put({"event": "session", "detail": "starting session container"})
+                try:
+                    await ensure_session_running(sub_slug, session_metadata, user_id)
+                except Exception as e:
+                    await progress_queue.put({"event": "error",
+                                              "detail": f"Could not start session container: {e}"})
+                    return
+                await progress_queue.put({"event": "session", "detail": "container ready"})
+
+                # 2. Data source (server-side re-reads) + container executor (jail).
+                data = await _build_data_source(sub_slug, sub_study_meta)
+                # Pre-warm the cached datasets off the event loop — the first read
+                # parses renorm/samples/taxonomy/provenance JSON and would otherwise
+                # block every other in-flight request inline (large taxonomy files).
+                await asyncio.to_thread(data.datasets)
+                from .autoresearch_executor import ContainerExecutor  # Task B (portal-side)
+                try:
+                    executor = ContainerExecutor(
+                        sub_slug, default_timeout=settings.autoresearch_max_analysis_s)
+                except TypeError:
+                    # Forward-compatible with the design's ContainerExecutor(slug)
+                    # signature; per-exec timeout then falls to the executor default.
+                    executor = ContainerExecutor(sub_slug)
+
+                # 3. LLM client (server-side; tool-calling passes straight through).
+                llm_client = LLMClient(
+                    AsyncOpenAI(base_url=llm["base_url"], api_key=llm["api_key"]),
+                    model=llm["model"])
+
+                ar = Autoresearcher(
+                    data, llm_client, executor,
+                    explore_model=settings.role_model("explore", llm["model"]),
+                    verify_model=settings.role_model("verify", llm["model"]),
+                    max_steps=settings.autoresearch_max_steps,
+                    max_followups=settings.autoresearch_max_followups,
+                    reconcile=settings.autoresearch_reconcile_enabled,
+                    on_progress=on_progress)
+
+                # 4. Explore (time-budgeted) → verify → write prose → snapshot.
+                completed = await asyncio.wait_for(
+                    ar.explore(), timeout=settings.autoresearch_time_budget_s)
+                await progress_queue.put({"event": "verify",
+                                          "detail": "re-executing claims for verification"})
+                await ar.verify()
+                await progress_queue.put({"event": "write", "detail": "writing Results prose"})
+                await ar.write_results()
+                result_holder["snapshot"] = ar.snapshot(resolve=True, completed=completed)
+            except asyncio.TimeoutError:
+                result_holder["error"] = "time budget exceeded"
+                await progress_queue.put({"event": "error",
+                                          "detail": "Autoresearch exceeded its time budget."})
+            except Exception as e:
+                result_holder["error"] = str(e)
+                logger.exception(f"Autoresearch run failed for {sub_slug}")
+                await progress_queue.put({"event": "error", "detail": str(e)})
+            finally:
+                await progress_queue.put(None)
+
+        asyncio.create_task(run())
+
+        while True:
+            msg = await progress_queue.get()
+            if msg is None:
+                break
+            yield f"data: {json.dumps(msg, default=str)}\n\n"
+
+        # Persist the snapshot in a FRESH session (the request db is out of scope).
+        if "snapshot" in result_holder:
+            snapshot = result_holder["snapshot"]
+            yield f"data: {json.dumps({'event': 'start', 'detail': 'Saving autoresearch results...'})}\n\n"
+            try:
+                interview_data = dict(sub_interview)
+                interview_data["_autoresearch"] = snapshot
+                # Provenance: name the backend/model that produced this run (#16 idiom).
+                interview_data["_autoresearch_model"] = llm.get("label")
+                interview_data["_autoresearch_backend"] = llm.get("backend")
+
+                async with async_session() as save_db:
+                    save_result = await save_db.execute(
+                        select(Submission).where(Submission.id == sub_id))
+                    sub = save_result.scalar_one()
+                    sub.interview_data = interview_data
+                    # flag_modified is mandatory — JSON mutation isn't autodetected.
+                    attributes.flag_modified(sub, "interview_data")
+                    await save_db.commit()
+            except Exception as e:
+                yield f"data: {json.dumps({'event': 'error', 'detail': f'Save failed: {e}'})}\n\n"
+                return
+
+            # Optional: commit the Results prose to the paper repo's .omc/ via a PR.
+            if settings.autoresearch_commit_enabled and sub_github_repo:
+                results_md = snapshot.get("results_prose") or ""
+                if results_md.strip():
+                    try:
+                        from .github_integration import create_review_pr
+                        # "https://github.com/org/micro-0001" → "org/micro-0001"
+                        repo_full_name = "/".join(
+                            sub_github_repo.rstrip("/").split("/")[-2:])
+                        pr_url = await create_review_pr(
+                            repo_full_name, [{"body": results_md}], "autoresearch")
+                        yield f"data: {json.dumps({'event': 'commit', 'detail': pr_url})}\n\n"
+                    except Exception as e:
+                        logger.warning(f"Autoresearch .omc commit failed for {sub_slug}: {e}")
+                        yield f"data: {json.dumps({'event': 'commit', 'detail': f'commit skipped: {e}'})}\n\n"
+
+            complete = {
+                "event": "complete",
+                "detail": "Autoresearch complete — view the provenance ledger",
+                "ledger_url": f"/autoresearch/{sub_slug}/provenance",
+            }
+            yield f"data: {json.dumps(complete)}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+# ── provenance viewer ─────────────────────────────────────────────────────────
+@router.get("/{slug}/provenance")
+async def provenance_viewer(
+    slug: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Render the provenance DAG viewer for a completed autoresearch run.
+
+    Mirrors ``main.manuscript_preview``: owner-scoped load, redirect to the
+    submission page when no run exists. The persisted snapshot is already fully
+    resolved (``snapshot(resolve=True)``), so ``provenance.html`` is pure-render —
+    it consumes ``data_json`` and imports nothing from the bench / ``ai``."""
+    user = await get_current_user(request, db)
+    if not user:
+        return templates.TemplateResponse("login_required.html", {"request": request})
+
+    stmt = select(Submission).where(
+        Submission.slug == slug,
+        Submission.user_id == user.id,
+        Submission.deleted_at.is_(None),
+    )
+    result = await db.execute(stmt)
+    submission = result.scalar_one_or_none()
+    if not submission:
+        return templates.TemplateResponse(
+            "404.html", {"request": request, "user": user}, status_code=404)
+
+    interview_data = submission.interview_data or {}
+    snapshot = interview_data.get("_autoresearch")
+    if not snapshot:
+        return RedirectResponse(f"/submissions/{slug}", status_code=303)
+
+    return templates.TemplateResponse(
+        "provenance.html",
+        {
+            "request": request,
+            "user": user,
+            "submission": submission,
+            # Embedded in a <script> block: escape so model-generated content
+            # (claim text / run_analysis code) can't break out via </script> or
+            # inject markup (stored-XSS guard). Escapes <, >, & and U+2028/U+2029.
+            "data_json": (json.dumps(snapshot, default=str)
+                          .replace("<", "\\u003c").replace(">", "\\u003e")
+                          .replace("&", "\\u0026").replace("\u2028", "\\u2028")
+                          .replace("\u2029", "\\u2029")),
+            "model_label": interview_data.get("_autoresearch_model"),
+        },
+    )

--- a/portal/app/autoresearch_executor.py
+++ b/portal/app/autoresearch_executor.py
@@ -1,6 +1,6 @@
 """Production ``CodeExecutor`` — runs model-written analysis code INSIDE the
 isolated ``omc-session-{slug}`` container via ``docker exec``, never on the portal
-host. The container is the jail (issue #29): the ``omc-sessions`` bridge drops all
+host. The container is the sandbox (issue #29): the ``omc-sessions`` bridge drops all
 outbound except the portal proxy, ``/data`` is a read-only squashfuse mount, and
 the container is capped at 2g/1cpu and ephemeral (see ``portal/app/sessions.py``).
 

--- a/portal/app/autoresearch_executor.py
+++ b/portal/app/autoresearch_executor.py
@@ -1,0 +1,74 @@
+"""Production ``CodeExecutor`` — runs model-written analysis code INSIDE the
+isolated ``omc-session-{slug}`` container via ``docker exec``, never on the portal
+host. The container is the jail (issue #29): the ``omc-sessions`` bridge drops all
+outbound except the portal proxy, ``/data`` is a read-only squashfuse mount, and
+the container is capped at 2g/1cpu and ephemeral (see ``portal/app/sessions.py``).
+
+The child runner is the SAME ``_SUBPROCESS_RUNNER`` the dev/offline
+``SubprocessExecutor`` uses (imported from ``ai.autoresearch``), so re-execution
+at verification time is byte-identical to exploration time — it reads the viz
+JSON from ``/data/viz/data`` (the ``.sqsh`` bind-mounted read-only) inside the
+container and prints a single JSON line (``{"__ok__": ...}`` or ``{"__err__": ...}``).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from ai.autoresearch import _SUBPROCESS_RUNNER
+
+logger = logging.getLogger(__name__)
+
+# The submission's viz JSON inside the container: the .sqsh is bind-mounted
+# read-only at /data (sessions.py: -v {mount}:/data:ro), and the amplicon viz
+# lives under viz/data (matching the host path the DirDataSource reads).
+CONTAINER_DATA_DIR = "/data/viz/data"
+
+
+class ContainerExecutor:
+    """``CodeExecutor`` that executes a cell in the running session container.
+
+    Implements the protocol ``async run(code, timeout) -> (ok, result_or_error)``.
+    """
+
+    def __init__(self, slug: str, default_timeout: int = 60,
+                 data_dir: str = CONTAINER_DATA_DIR):
+        self.container = f"omc-session-{slug}"
+        self.default_timeout = default_timeout
+        self.data_dir = data_dir
+
+    async def run(self, code: str, timeout: int | None = None) -> tuple[bool, Any]:
+        t = int(timeout or self.default_timeout)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "exec", "-i",
+                "-e", f"EXPLORER_DATA_DIR={self.data_dir}",
+                # single-threaded BLAS — deterministic + small virtual footprint
+                "-e", "OMP_NUM_THREADS=1", "-e", "OPENBLAS_NUM_THREADS=1", "-e", "MKL_NUM_THREADS=1",
+                self.container, "python3", "-c", _SUBPROCESS_RUNNER,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return False, "docker not available on host"
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(code.encode()), timeout=t + 5)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            return False, f"timeout >{t}s"
+
+        out = (stdout or b"").decode(errors="replace").strip().splitlines()
+        try:
+            r = json.loads(out[-1]) if out else {}
+        except json.JSONDecodeError:
+            err = ((stderr or b"").decode(errors="replace")
+                   or "\n".join(out) or "no output").strip().splitlines()
+            return False, (err[-1] if err else "error")[:200]
+        return (True, r["__ok__"]) if "__ok__" in r else (False, r.get("__err__", "error"))

--- a/portal/app/config.py
+++ b/portal/app/config.py
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
 
     # Claim-grounded autoresearch (issue #29). An author drives an autonomous
     # analysis run over their pipeline data: the agent proposes an agenda, runs
-    # its own analysis code inside the isolated session container (the jail),
+    # its own analysis code inside the isolated session container (the sandbox),
     # records verifiable claims, then a two-layer verification (deterministic
     # re-execution + skeptical reconciliation) grades each claim before the
     # Results prose is written from the verified ones. Off by default — it needs
@@ -70,7 +70,7 @@ class Settings(BaseSettings):
     autoresearch_max_steps: int = 48          # agent tool-call budget per run
     autoresearch_max_followups: int = 12      # cap on self-added agenda items
     autoresearch_time_budget_s: int = 1800    # wall-clock cap on explore()
-    autoresearch_max_analysis_s: int = 60     # per run_analysis exec timeout (in-jail)
+    autoresearch_max_analysis_s: int = 60     # per run_analysis exec timeout (in-sandbox)
     autoresearch_reconcile_enabled: bool = True   # skeptical-model verify fallback
     autoresearch_commit_enabled: bool = False     # PR the Results prose to .omc/
     # Per-role model overrides for the two autoresearch phases (fall back to

--- a/portal/app/config.py
+++ b/portal/app/config.py
@@ -59,6 +59,25 @@ class Settings(BaseSettings):
     # models with negligible cost on stronger ones. Doubles per-section LLM calls.
     manuscript_outline_first: bool = True
 
+    # Claim-grounded autoresearch (issue #29). An author drives an autonomous
+    # analysis run over their pipeline data: the agent proposes an agenda, runs
+    # its own analysis code inside the isolated session container (the jail),
+    # records verifiable claims, then a two-layer verification (deterministic
+    # re-execution + skeptical reconciliation) grades each claim before the
+    # Results prose is written from the verified ones. Off by default — it needs
+    # completed pipeline results (.sqsh) and a running session container.
+    autoresearch_enabled: bool = False
+    autoresearch_max_steps: int = 48          # agent tool-call budget per run
+    autoresearch_max_followups: int = 12      # cap on self-added agenda items
+    autoresearch_time_budget_s: int = 1800    # wall-clock cap on explore()
+    autoresearch_max_analysis_s: int = 60     # per run_analysis exec timeout (in-jail)
+    autoresearch_reconcile_enabled: bool = True   # skeptical-model verify fallback
+    autoresearch_commit_enabled: bool = False     # PR the Results prose to .omc/
+    # Per-role model overrides for the two autoresearch phases (fall back to
+    # llm_model, like the manuscript roles above).
+    llm_model_explore: str = ""               # the agenda-driven agent loop
+    llm_model_verify: str = ""                # the skeptical reconciler
+
     # Database
     database_url: str = "sqlite+aiosqlite:///./omc.db"
 
@@ -128,7 +147,8 @@ class Settings(BaseSettings):
         return {x.strip().lower() for x in self.admin_github_logins.split(",") if x.strip()}
 
     def role_model(self, role: str, default: str = "") -> str:
-        """Model for an AI role ('draft' | 'cite' | 'review'), or `default`.
+        """Model for an AI role ('draft' | 'cite' | 'review' | 'explore' |
+        'verify'), or `default`.
 
         Returns the per-role override when configured, else `default` (the
         caller's resolved model) so per-user backend choices still apply.
@@ -137,6 +157,8 @@ class Settings(BaseSettings):
             "draft": self.llm_model_draft,
             "cite": self.llm_model_cite,
             "review": self.llm_model_review,
+            "explore": self.llm_model_explore,
+            "verify": self.llm_model_verify,
         }.get(role, "")
         return override or default
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -25,6 +25,7 @@ from .auth import router as auth_router, get_current_user, is_admin, require_adm
 from .submissions import router as submissions_router
 from .interviews import router as interviews_router
 from .reviews import router as reviews_router
+from .autoresearch import router as autoresearch_router
 from .metadata import router as metadata_router
 from .staging import router as staging_router
 from .sessions import router as sessions_router
@@ -90,6 +91,7 @@ app.include_router(auth_router)
 app.include_router(submissions_router)
 app.include_router(interviews_router)
 app.include_router(reviews_router)
+app.include_router(autoresearch_router)
 app.include_router(metadata_router)
 app.include_router(staging_router)
 app.include_router(sessions_router)
@@ -551,7 +553,10 @@ async def submission_detail(
     return templates.TemplateResponse(
         "submission_detail.html",
         {"request": request, "user": user, "submission": submission,
-         "pipeline_versions": pipeline_versions, "known_primers": known_primers},
+         "pipeline_versions": pipeline_versions, "known_primers": known_primers,
+         # settings is needed by the autoresearch trigger partial (Step 3) to gate
+         # itself on settings.autoresearch_enabled.
+         "settings": settings},
     )
 
 

--- a/portal/templates/_autoresearch_trigger.html
+++ b/portal/templates/_autoresearch_trigger.html
@@ -1,0 +1,156 @@
+{#
+  Autoresearch trigger + progress partial.
+
+  Include this inside Step 3 of submission_detail.html (within a `wf-step`),
+  where these variables are already in scope:
+    submission            — the Submission (for .slug and .interview_data)
+    has_pipeline_results   — bool gate (results present)
+    settings               — app Settings (for .autoresearch_enabled)
+  and where the parent scripts block has already defined the globals
+    subId, showStatus(msg), showPersistentStatus(msg)
+  (runAutoresearch below reuses them when present, and degrades gracefully if not).
+
+  Integrator: add `{% include "_autoresearch_trigger.html" %}` beside the
+  "Generate Manuscript" button. No new template context is required beyond the
+  variables listed above. Requires `settings` in the template context and
+  `settings.autoresearch_enabled` in config.py (Task E).
+
+  Backend contract (Task C):
+    POST /autoresearch/{slug}/run-stream   — SSE: session/agenda/run_analysis/
+                                             record_claim/verify/reconcile/complete/error
+    GET  /autoresearch/{slug}/provenance   — the claim-provenance viewer
+#}
+{% if settings and settings.autoresearch_enabled %}
+{% set has_autoresearch = submission.interview_data and submission.interview_data.get('_autoresearch') %}
+<div class="wf-step-actions" style="margin-top: 0.5rem;">
+    <button class="btn btn-secondary" onclick="runAutoresearch()"
+        {% if not has_pipeline_results %}title="Available once pipeline results are ready" disabled{% endif %}>
+        {% if has_autoresearch %}Re-run Autoresearch{% else %}Run Autoresearch{% endif %}
+    </button>
+    {% if has_autoresearch %}
+    <a href="/autoresearch/{{ submission.slug }}/provenance" class="btn btn-secondary">View Provenance</a>
+    {% endif %}
+</div>
+
+{# ── Autoresearch progress log ── #}
+<div id="ar-progress" style="display:none; margin-top: 1rem;">
+    <div id="ar-terminal" style="background: #0a0a0a; border-radius: 0.5rem; padding: 1rem 1.25rem; font-family: var(--font-mono); font-size: 0.8125rem; max-height: 500px; overflow-y: auto;">
+        <div id="ar-log" style="color: #4ade80; line-height: 1.7; white-space: pre-wrap;"></div>
+    </div>
+</div>
+
+<script>
+async function runAutoresearch() {
+    const progressDiv = document.getElementById('ar-progress');
+    const logDiv = document.getElementById('ar-log');
+    progressDiv.style.display = '';
+    logDiv.innerHTML = '';
+    if (typeof showPersistentStatus === 'function') showPersistentStatus('Running autoresearch...');
+
+    function scrollLog() {
+        const term = document.getElementById('ar-terminal');
+        term.scrollTop = term.scrollHeight;
+    }
+
+    function appendLog(text, color) {
+        const line = document.createElement('div');
+        line.style.color = color || '#4ade80';
+        line.textContent = `[${new Date().toLocaleTimeString()}] ${text}`;
+        logDiv.appendChild(line);
+        scrollLog();
+    }
+
+    // Compact one-line rendering of an event's detail payload.
+    function fmtDetail(detail) {
+        if (detail == null) return '';
+        if (typeof detail === 'string') return detail;
+        try {
+            if (detail.statement) return detail.statement + (detail.verdict ? ` [${detail.verdict}]` : '');
+            if (detail.question) return detail.question;
+            if (detail.label) return detail.label;
+            return JSON.stringify(detail);
+        } catch (e) {
+            return String(detail);
+        }
+    }
+
+    appendLog('Starting claim-grounded autoresearch...');
+
+    try {
+        const resp = await fetch(`/autoresearch/${subId}/run-stream`, {
+            method: 'POST', credentials: 'same-origin',
+        });
+
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            appendLog(`ERROR: ${err.detail || resp.statusText}`, '#ef4444');
+            if (typeof showStatus === 'function') showStatus(`Error: ${err.detail || resp.statusText}`);
+            return;
+        }
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+
+            const lines = buffer.split('\n');
+            buffer = lines.pop();
+
+            for (const line of lines) {
+                if (!line.startsWith('data: ')) continue;
+                let msg;
+                try {
+                    msg = JSON.parse(line.slice(6));
+                } catch (e) {
+                    continue;
+                }
+                const d = fmtDetail(msg.detail);
+                switch (msg.event) {
+                    case 'session':
+                        appendLog(`session: ${d}`, '#38bdf8');
+                        if (typeof showPersistentStatus === 'function') showPersistentStatus('Session ready — exploring...');
+                        break;
+                    case 'agenda':
+                        appendLog(`agenda: ${d}`, '#c084fc');
+                        break;
+                    case 'run_analysis':
+                        appendLog(`analysis: ${d}`, '#facc15');
+                        break;
+                    case 'record_claim':
+                        appendLog(`claim: ${d}`, '#4ade80');
+                        break;
+                    case 'verify':
+                        appendLog(`verify: ${d}`, '#86efac');
+                        break;
+                    case 'reconcile':
+                        appendLog(`reconcile: ${d}`, '#5eead4');
+                        break;
+                    case 'error':
+                        appendLog(`ERROR: ${d}`, '#ef4444');
+                        if (typeof showStatus === 'function') showStatus(`Error: ${d}`);
+                        break;
+                    case 'complete':
+                        appendLog(d || 'Autoresearch complete.', '#22c55e');
+                        if (typeof showStatus === 'function') showStatus('Autoresearch complete! Opening provenance...');
+                        if (msg.ledger_url) {
+                            setTimeout(() => window.location.href = msg.ledger_url, 1500);
+                        } else {
+                            setTimeout(() => location.reload(), 2000);
+                        }
+                        break;
+                    default:
+                        if (d) appendLog(`${msg.event}: ${d}`);
+                }
+            }
+        }
+    } catch (e) {
+        appendLog(`ERROR: ${e.message}`, '#ef4444');
+        if (typeof showStatus === 'function') showStatus(`Error: ${e.message}`);
+    }
+}
+</script>
+{% endif %}

--- a/portal/templates/provenance.html
+++ b/portal/templates/provenance.html
@@ -1,0 +1,278 @@
+{% extends "base.html" %}
+
+{#
+  Claim-provenance viewer for claim-grounded autoresearch.
+
+  Adapted from the self-contained bench viewer tests/bench/build_dag_artifact.py.
+  Renders the server-persisted autoresearch snapshot (schema: portal/app design §4).
+  The template is PURE-RENDER: every antecedent arrives already resolved in the
+  snapshot's per-claim `resolved` list, so no data re-reads happen in the browser.
+
+  Context expected from the route (Task C):
+    data_json  — json.dumps(snapshot)   [REQUIRED]  the §4 snapshot dict:
+                   {claims, computations, agenda, dag, results_prose, run}
+    submission — optional; used only for the header study line + back link.
+
+  Self-contained: no external assets beyond what base.html already loads.
+#}
+
+{% block title %}Claim Provenance — {{ submission.title or submission.slug if submission else 'Autoresearch' }} - OMC{% endblock %}
+
+{% block head %}
+<style>
+:root{
+  --bg:#f4f7f6; --panel:#ffffff; --panel2:#eef2f1; --border:#d8e0df;
+  --text:#13211f; --muted:#5a6a68; --accent:#0f8a80;
+  --verified:#1f7a3d; --refuted:#c0392b; --unverifiable:#b07d15;
+  --computation:#2266b8; --data:#5a6f6c;
+  --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+}
+@media (prefers-color-scheme:dark){:root{
+  --bg:#0d1413; --panel:#131c1b; --panel2:#0f1716; --border:#243130;
+  --text:#d7e1df; --muted:#899997; --accent:#34d3c3;
+  --verified:#49c96e; --refuted:#f0685c; --unverifiable:#e2b53f;
+  --computation:#5aa2ee; --data:#9fb0ad;
+}}
+:root[data-theme="light"]{
+  --bg:#f4f7f6; --panel:#ffffff; --panel2:#eef2f1; --border:#d8e0df;
+  --text:#13211f; --muted:#5a6a68; --accent:#0f8a80;
+  --verified:#1f7a3d; --refuted:#c0392b; --unverifiable:#b07d15; --computation:#2266b8; --data:#5a6f6c;
+}
+:root[data-theme="dark"]{
+  --bg:#0d1413; --panel:#131c1b; --panel2:#0f1716; --border:#243130;
+  --text:#d7e1df; --muted:#899997; --accent:#34d3c3;
+  --verified:#49c96e; --refuted:#f0685c; --unverifiable:#e2b53f; --computation:#5aa2ee; --data:#9fb0ad;
+}
+.prov-wrap *{box-sizing:border-box}
+.prov-wrap{max-width:1100px;margin:0 auto;padding:8px 4px 60px;
+  color:var(--text);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}
+.prov-wrap .back{display:inline-block;font-size:13px;color:var(--muted);text-decoration:none;margin-bottom:14px}
+.prov-wrap .back:hover{color:var(--accent)}
+.prov-wrap header{border-bottom:1px solid var(--border);padding-bottom:18px;margin-bottom:22px}
+.prov-wrap .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--accent);margin:0 0 8px}
+.prov-wrap h1{font-size:clamp(22px,3.4vw,30px);margin:0 0 6px;letter-spacing:-.02em;text-wrap:balance;font-weight:650}
+.prov-wrap .sub{color:var(--muted);font-size:14px;margin:0}
+.prov-wrap .stats{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px}
+.prov-wrap .stat{background:var(--panel);border:1px solid var(--border);border-radius:10px;
+  padding:10px 14px;min-width:96px}
+.prov-wrap .stat .n{font-family:var(--mono);font-size:22px;font-variant-numeric:tabular-nums;font-weight:600}
+.prov-wrap .stat .l{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.06em}
+.prov-wrap .stat.ok .n{color:var(--verified)} .prov-wrap .stat.no .n{color:var(--refuted)}
+.prov-wrap .lede{background:var(--panel);border:1px solid var(--border);border-left:3px solid var(--accent);
+  border-radius:10px;padding:13px 16px;margin:20px 0 6px;font-size:14px;color:var(--text)}
+.prov-wrap .lede b{color:var(--accent)}
+.prov-wrap .grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.15fr);gap:18px;margin-top:20px}
+@media(max-width:760px){.prov-wrap .grid{grid-template-columns:1fr}}
+.prov-wrap .col-h{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin:0 0 10px}
+.prov-wrap ul.claims{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:7px;
+  max-height:64vh;overflow:auto}
+.prov-wrap button.claim{width:100%;text-align:left;background:var(--panel);border:1px solid var(--border);
+  border-radius:9px;padding:10px 12px;cursor:pointer;color:var(--text);font:inherit;
+  display:flex;gap:10px;align-items:flex-start;transition:border-color .12s,background .12s}
+.prov-wrap button.claim:hover{border-color:var(--accent)}
+.prov-wrap button.claim[aria-selected="true"]{border-color:var(--accent);background:var(--panel2);
+  box-shadow:inset 3px 0 0 var(--accent)}
+.prov-wrap button.claim:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.prov-wrap .dot{width:9px;height:9px;border-radius:50%;margin-top:6px;flex:0 0 auto}
+.prov-wrap .dot.verified{background:var(--verified)} .prov-wrap .dot.refuted{background:var(--refuted)}
+.prov-wrap .dot.unverifiable{background:var(--unverifiable)}
+.prov-wrap .claim .txt{font-size:13.5px;min-width:0}
+.prov-wrap .claim .cid{font-family:var(--mono);font-size:11px;color:var(--muted)}
+.prov-wrap .kind{display:inline-block;font-family:var(--mono);font-size:10px;letter-spacing:.04em;
+  padding:1px 6px;border-radius:5px;border:1px solid var(--border);color:var(--muted);margin-left:6px}
+.prov-wrap .kind.caveat{color:var(--unverifiable);border-color:var(--unverifiable)}
+.prov-wrap .kind.anomaly{color:var(--refuted);border-color:var(--refuted)}
+.prov-wrap .kind.pattern{color:var(--accent);border-color:var(--accent)}
+.prov-wrap .detail{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:18px;
+  position:sticky;top:16px;max-height:78vh;overflow:auto}
+.prov-wrap .badge{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11px;
+  letter-spacing:.05em;text-transform:uppercase;padding:3px 9px;border-radius:20px;font-weight:600}
+.prov-wrap .badge.verified{background:color-mix(in srgb,var(--verified) 16%,transparent);color:var(--verified)}
+.prov-wrap .badge.refuted{background:color-mix(in srgb,var(--refuted) 16%,transparent);color:var(--refuted)}
+.prov-wrap .badge.unverifiable{background:color-mix(in srgb,var(--unverifiable) 16%,transparent);color:var(--unverifiable)}
+.prov-wrap .badge.method{background:color-mix(in srgb,var(--accent) 14%,transparent);color:var(--accent);
+  margin-left:8px;text-transform:none;letter-spacing:.02em}
+.prov-wrap .chip{font-family:var(--mono);font-size:10px;color:var(--accent);border:1px solid var(--accent);
+  border-radius:5px;padding:0 5px;margin-left:6px;opacity:.85;text-transform:none}
+.prov-wrap .detail h2{font-size:17px;margin:12px 0 8px;line-height:1.35;text-wrap:balance;font-weight:600}
+.prov-wrap .kv{font-family:var(--mono);font-size:13px;background:var(--panel2);border:1px solid var(--border);
+  border-radius:7px;padding:8px 11px;margin:8px 0;display:flex;gap:8px}
+.prov-wrap .kv .k{color:var(--muted)} .prov-wrap .kv .v{font-variant-numeric:tabular-nums;word-break:break-word}
+.prov-wrap .prov-h{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);
+  margin:20px 0 8px;border-top:1px solid var(--border);padding-top:14px}
+.prov-wrap .ant{border:1px solid var(--border);border-radius:9px;padding:10px 12px;margin:8px 0;background:var(--panel2)}
+.prov-wrap .ant .type{font-family:var(--mono);font-size:10px;letter-spacing:.05em;text-transform:uppercase;
+  padding:1px 6px;border-radius:5px;color:#fff}
+.prov-wrap .ant .type.computation{background:var(--computation)} .prov-wrap .ant .type.data{background:var(--data)}
+.prov-wrap .ant .lab{font-family:var(--mono);font-size:12.5px;margin-left:8px;color:var(--text)}
+.prov-wrap pre{margin:9px 0 0;background:var(--bg);border:1px solid var(--border);border-radius:7px;
+  padding:10px 12px;overflow-x:auto;font-family:var(--mono);font-size:12px;line-height:1.45;color:var(--text)}
+.prov-wrap .ant .val{font-family:var(--mono);font-size:12px;color:var(--muted);margin-top:6px;
+  word-break:break-word;font-variant-numeric:tabular-nums}
+.prov-wrap .reverify{font-size:12px;color:var(--muted);margin-top:6px}
+.prov-wrap .reverify b{color:var(--verified)}
+.prov-wrap .reconcile{font-size:12px;color:var(--muted);margin-top:8px;padding:8px 11px;border-radius:7px;
+  background:color-mix(in srgb,var(--accent) 8%,transparent);border:1px solid var(--border)}
+.prov-wrap .reconcile b{color:var(--accent)}
+.prov-wrap .foot{margin-top:34px;padding-top:16px;border-top:1px solid var(--border);color:var(--muted);font-size:12.5px}
+.prov-wrap .foot code{font-family:var(--mono);background:var(--panel2);padding:1px 5px;border-radius:4px}
+.prov-wrap .empty{color:var(--muted);font-size:13px;padding:20px 4px}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="wrap prov-wrap">
+  {% if submission %}
+  <a class="back" href="/submissions/{{ submission.slug }}">&larr; Back to Submission</a>
+  {% endif %}
+  <header>
+    <p class="eyebrow">Autoresearch · claim ledger</p>
+    <h1>Every number traces to data or the code that produced it</h1>
+    <p class="sub" id="study">{% if submission %}{{ submission.title or submission.slug }} · agenda-driven autoresearch{% endif %}</p>
+    <div class="stats" id="stats"></div>
+  </header>
+
+  <div class="lede">
+    Claims are the currency. Each was recorded by an agent exploring the pipeline data, and
+    each carries a machine-checkable provenance — a <b>data path</b> or a re-runnable
+    <b>computation</b>. An independent pass re-derived every one; only <b>verified</b> claims
+    reach the manuscript. Select a claim to see what backs it.
+  </div>
+
+  <div class="grid">
+    <section>
+      <p class="col-h">Claims</p>
+      <ul class="claims" id="list"></ul>
+    </section>
+    <aside>
+      <p class="col-h">Provenance</p>
+      <div class="detail" id="detail"><p class="empty">Select a claim to inspect its provenance.</p></div>
+    </aside>
+  </div>
+
+  <p class="foot">Data path claims re-read the pipeline output; computation claims re-execute
+  the stored code. The ledger is self-contained — any model or reviewer can re-run
+  <code>verify()</code> and check every claim for themselves.</p>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+// The server-persisted autoresearch snapshot (schema §4). Already fully resolved.
+const DATA = {{ data_json | safe }};
+const CLAIMS = DATA.claims || [];
+const COMPS = DATA.computations || {};
+const AGENDA = DATA.agenda || [];
+const RUN = DATA.run || {};
+
+const esc = s => String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+const fmt = v => (typeof v === 'string' ? v : JSON.stringify(v));
+const trunc = (v, n) => { const s = (v == null ? '' : fmt(v)); return s.length > n ? s.slice(0, n) : s; };
+
+// Preliminary banner when exploration stopped before completing the agenda.
+if (RUN && RUN.completed === false) {
+  const b = document.createElement('div');
+  b.className = 'lede';
+  b.style.borderLeftColor = 'var(--unverifiable)';
+  const done = RUN.investigations_done ?? 0;
+  const total = RUN.investigations_total ?? 0;
+  b.innerHTML = `<b style="color:var(--unverifiable)">⚠️ Preliminary</b> — exploration stopped `
+    + `with ${done}/${total} investigations done; these claims are partial.`;
+  document.querySelector('.prov-wrap header').after(b);
+}
+
+// Stats computed client-side from the snapshot (schema §4 carries no precomputed stats).
+const S = {
+  claims: CLAIMS.length,
+  verified: CLAIMS.filter(c => c.verdict === 'verified').length,
+  insights: CLAIMS.filter(c => c.kind === 'pattern' || c.kind === 'anomaly').length,
+  computations: Object.keys(COMPS).length,
+  investigations: AGENDA.length,
+};
+document.getElementById('stats').innerHTML = [
+  ['claims', S.claims, ''], ['verified', S.verified, 'ok'],
+  ['insights', S.insights, ''], ['investigations', S.investigations, ''],
+  ['computations', S.computations, '']
+].map(([l,n,c]) => `<div class="stat ${c}"><div class="n">${n}</div><div class="l">${l}</div></div>`).join('');
+
+const KIND = {quality_caveat:['caveat','caveat'], anomaly:['anomaly','anomaly'], pattern:['pattern','pattern']};
+
+const list = document.getElementById('list');
+if (!CLAIMS.length) {
+  list.innerHTML = '<li class="empty">No claims were recorded in this run.</li>';
+}
+CLAIMS.forEach((c,i) => {
+  const b = document.createElement('button');
+  b.className = 'claim'; b.setAttribute('role','option'); b.dataset.i = i;
+  b.setAttribute('aria-selected','false');
+  const nd = [...new Set((c.method||'').split(',').map(s=>s.split(':')[0].trim()).filter(x=>x && x!=='direct'))];
+  const chipMap = {'x100':'frac→%','/100':'%→frac','derived':'derived'};
+  const chip = (c.verdict==='verified' && nd.length)
+    ? `<span class="chip">${nd.map(x=>chipMap[x]||x).join(' · ')}</span>` : '';
+  const k = KIND[c.kind];
+  const kindChip = k ? `<span class="kind ${k[1]}">${k[0]}</span>` : '';
+  b.innerHTML = `<span class="dot ${c.verdict}"></span><span class="txt">`
+    + `<span class="cid">${esc(c.id)}</span>` + kindChip + chip
+    + `<br>${esc(c.statement)}</span>`;
+  b.onclick = () => select(i);
+  list.appendChild(b);
+});
+
+// Resolve one antecedent (schema §4 `resolved` item: {ant, code?, result?, value?}).
+// A `code` field marks a computation; otherwise it's a data-path read.
+function resolvedCard(a){
+  if (a && a.code !== undefined && a.code !== null){
+    const comp = COMPS[a.ant] || {};
+    const label = comp.label || a.ant;
+    const result = a.result !== undefined ? a.result : comp.result;
+    return `<div class="ant"><span class="type computation">computation</span>`
+      + `<span class="lab">${esc(a.ant)} · ${esc(label)}</span>`
+      + `<pre>${esc(a.code)}</pre>`
+      + `<div class="val">→ ${esc(trunc(result, 1200))}</div></div>`;
+  }
+  const val = (a && a.value !== undefined) ? trunc(a.value, 300) : '—';
+  return `<div class="ant"><span class="type data">data</span>`
+    + `<span class="lab">${esc(a && a.ant || '')}</span>`
+    + `<div class="val">= ${esc(val)}</div></div>`;
+}
+
+function select(i){
+  const c = CLAIMS[i];
+  if (!c) return;
+  [...list.children].forEach((el,j)=>{ if (el.setAttribute) el.setAttribute('aria-selected', j===i); });
+  const resolved = c.resolved || [];
+  const antCount = (c.antecedents || resolved).length;
+  const ants = resolved.map(resolvedCard).join('') || '<p class="empty">No antecedents recorded.</p>';
+  const how = {direct:'a direct data/computation read', 'x100':'a unit conversion (fraction→%)',
+    '/100':'a unit conversion (%→fraction)', 'derived':'a derivation from its inputs',
+    reconciled:'a skeptical model adjudication against the re-executed evidence'};
+  const name = {direct:'direct read','x100':'fraction→%','/100':'%→fraction',derived:'derived',
+    reconciled:'model-reconciled'};
+  const parts = [...new Set((c.method||'').split(',').map(s=>s.trim()).filter(Boolean))];
+  const nonDirect = parts.filter(p=>p.split(':')[0] !== 'direct');
+  const pick = (nonDirect.length ? nonDirect : parts);
+  const mlabel = pick.map(p=>{const[b,sub]=p.split(':'); return (name[b]||b)+(sub?` (${sub})`:'');}).join(' · ');
+  const methodBadge = (c.verdict==='verified' && mlabel)
+    ? `<span class="badge method" title="method: ${esc(c.method)}">✓ ${esc(mlabel)}</span>` : '';
+  const method = nonDirect.map(p=>p.split(':')[0])[0];
+  const via = method ? ` via ${how[method]||method}` : '';
+  const reverify = c.verdict==='verified'
+    ? `Re-derived from the antecedents below${via} — <b>verified</b>.`
+    : (c.verdict==='refuted'
+        ? 'The cited antecedents contradicted this value — <b style="color:var(--refuted)">refuted</b>, excluded from the manuscript.'
+        : 'No checkable antecedent — <b style="color:var(--unverifiable)">unverifiable</b>, excluded from the manuscript.');
+  const dk = KIND[c.kind];
+  document.getElementById('detail').innerHTML =
+    `<span class="badge ${c.verdict}">${esc(c.verdict||'unverifiable')}</span>` + methodBadge
+    + (dk ? `<span class="kind ${dk[1]}" style="margin-left:8px">${dk[0]}</span>` : '')
+    + `<h2>${esc(c.statement)}</h2>`
+    + `<div class="kv"><span class="k">value</span><span class="v">${esc(c.value)}</span></div>`
+    + `<div class="reverify">${reverify}</div>`
+    + (c.reconcile ? `<div class="reconcile"><b>Model adjudication:</b> ${esc((c.reconcile.reasoning||'').replace(/^VERDICT:[^\n]*\n?/i,''))}</div>` : '')
+    + `<p class="prov-h">Antecedents (${antCount})</p>${ants}`;
+}
+if (CLAIMS.length) select(0);
+</script>
+{% endblock %}

--- a/portal/templates/submission_detail.html
+++ b/portal/templates/submission_detail.html
@@ -599,6 +599,10 @@
                 <a href="/submissions/{{ submission.slug }}/manuscript" class="btn btn-primary">View Manuscript</a>
                 {% endif %}
             </div>
+            {# Claim-grounded autoresearch (issue #29). Renders nothing unless
+               settings.autoresearch_enabled. Reuses the parent's subId /
+               showStatus / showPersistentStatus globals. #}
+            {% include "_autoresearch_trigger.html" %}
             <p id="session-status" class="wf-step-desc" style="display:none; margin-top: 0.5rem;"></p>
 
             {# ── Generation progress log (inside step 3) ── #}

--- a/tests/bench/build_dag_artifact.py
+++ b/tests/bench/build_dag_artifact.py
@@ -11,7 +11,11 @@ from pathlib import Path
 HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE.parent.parent))
 sys.path.insert(0, str(HERE))
-from results_explorer import _navigate  # noqa: E402  (resolves data paths)
+from ai.autoresearch import DirDataSource  # noqa: E402  (resolves data paths)
+from fixtures import load_fixture, STUDY_GROUNDED, DATA_DIR  # noqa: E402
+
+# Resolve data-path antecedents against the same viz JSON the ledger was built from.
+_navigate = DirDataSource(DATA_DIR, study=STUDY_GROUNDED or {}, overview=load_fixture()).navigate
 
 # Optional: point at a specific run dir (e.g. writings/real_1543a4c1); default writings/.
 W = Path(sys.argv[1]) if len(sys.argv) > 1 else HERE / "writings"

--- a/tests/bench/results_explorer.py
+++ b/tests/bench/results_explorer.py
@@ -1,26 +1,26 @@
-"""Claim-centric autoresearch for the Results section (issue #29).
+"""Claim-centric autoresearch for the Results section (issue #29) — OFFLINE HARNESS.
+
+This is now a THIN CLI over the reusable core in ``ai/autoresearch.py``. The core
+holds the agenda loop, tools, two-layer verification (deterministic re-execution +
+skeptical model reconciliation), the provenance DAG, and the Results writer,
+refactored around injected collaborators. This file wires those to the bench's
+local pieces — the LM-Studio loader, a synchronous-endpoint ``AsyncOpenAI`` client,
+argparse, and file writing — so the offline eval stays reproducible:
+
+    python tests/bench/results_explorer.py            # fresh model run
+    python tests/bench/results_explorer.py --reverify [--reconcile]
 
 An agent EXPLORES the pipeline data — reading summaries AND running its own
-analysis code (Marimo-style) — and records a ledger of VERIFIABLE claims. Claims
-are the currency: each links to its ANTECEDENTS (the data paths and/or the
-computations it depends on), forming a provenance **DAG**. Every claim is
-re-derivable — a data claim by re-reading its path, a computed claim by
-re-executing its stored code — so any other model or human can verify it. Results
+analysis code — and records a ledger of VERIFIABLE claims, each linked to its
+antecedents (data paths and/or computations), forming a provenance DAG. Results
 prose is written from verified claims only.
 
-Phase 2: adds `run_analysis` (code execution over the real ASV count matrix) and
-a growing claim→antecedent DAG exported as JSON + a Mermaid diagram.
-
-Explorer model: qwen3.6-35b-a3b.
-
-Run:  python tests/bench/results_explorer.py
+Explorer model: env EXPLORER_MODEL (default qwen3.6-35b-a3b).
 Out:  writings/{claims_ledger.json, claims_dag.json, claims_dag.md, results_from_claims.md}
 """
-import gzip
+import asyncio
 import json
 import os
-import re
-import subprocess
 import sys
 import time
 from pathlib import Path
@@ -29,10 +29,11 @@ HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE.parent.parent))
 sys.path.insert(0, str(HERE))
 
-import numpy as np
-import pandas as pd
-from openai import OpenAI
-from ai.llm_client import _visible_and_finish
+from openai import AsyncOpenAI
+from ai.autoresearch import (
+    Autoresearcher, DirDataSource, LLMClient, SubprocessExecutor,
+    dag_mermaid, _flatten_numbers,
+)
 from ai.manuscript_checks import check_numbers_supported
 from fixtures import load_fixture, STUDY_GROUNDED, DATA_DIR
 from run_bench import _unload_all, _lms_load
@@ -47,8 +48,12 @@ OUT = HERE / "writings"
 OUT.mkdir(exist_ok=True)
 
 
-def _client():
-    return OpenAI(base_url=BASE_URL, api_key=API_KEY)
+def _client() -> LLMClient:
+    """The injected LLM collaborator: an async OpenAI-compatible tool-calling client.
+
+    (The bench endpoint is synchronous under the hood, but ``AsyncOpenAI`` drives it
+    fine and lets the same core run on the portal's real async backend.)"""
+    return LLMClient(AsyncOpenAI(base_url=BASE_URL, api_key=API_KEY), MODEL)
 
 
 def _ensure_model_loaded():
@@ -59,675 +64,137 @@ def _ensure_model_loaded():
     return _lms_load(MODEL, 65536, 300)[1]
 
 
-# ── Datasets (source of truth for reads + verification) ───────────────────────
-def _rj(name):
-    for p in (DATA_DIR / f"{name}.json", DATA_DIR / f"{name}.json.gz"):
-        if p.exists():
-            op = gzip.open if p.suffix == ".gz" else open
-            with op(p, "rt") as f:
-                return json.load(f)
-    return None
+def _data_source() -> DirDataSource:
+    """A ``DataSource`` over the bench data dir. ``overview`` comes from the committed
+    fixture snapshot (``load_fixture``) — kept explicit so the offline datasets match
+    the prototype byte-for-byte; ``study`` is the module-level ``STUDY_GROUNDED``
+    (which ``run_real_sample.py`` reassigns for a real submission)."""
+    return DirDataSource(DATA_DIR, study=STUDY_GROUNDED or {}, overview=load_fixture())
 
 
-def _build_datasets():
-    fx = load_fixture()
-    prov = _rj("provenance") or {}
-    samples = _rj("samples") or []
-    sg = STUDY_GROUNDED or {}
-    return {
-        "overview": fx,
-        # Stated study/methods context — the amplicon target here is the SRA metadata
-        # LABEL, which is frequently wrong; verify it against the observed taxonomy.
-        "study": {
-            "stated_target_label": sg.get("title"),
-            "study_name": sg.get("study_name"),
-            "organism": sg.get("organism"),
-            "platform": sg.get("platform"),
-            "taxonomy_database": fx.get("taxonomy_summary", {}).get("database"),
-            "pipeline_stages": [s.get("id") for s in prov.get("stages", [])],
-            "caveat": ("stated_target_label is the SRA-metadata amplicon label and can be "
-                       "wrong (18S runs are commonly mislabeled '16S'); confirm against tax Domain."),
-        },
-        "renorm_stats": _rj("renorm_stats") or fx.get("renorm", {}),
-        "provenance": {"total": prov.get("total", {}),
-                       "stages": [s.get("id") for s in prov.get("stages", [])],
-                       "n_samples": len(prov.get("samples", {}))},
-        "samples": {"n": len(samples),
-                    "total_reads": sum(s.get("total_reads", 0) for s in samples if isinstance(s, dict))},
-        "taxonomy_summary": fx.get("taxonomy_summary", {}),
-    }
+def _executor() -> SubprocessExecutor:
+    """The DEV/offline jail: a resource-limited subprocess over the same data dir."""
+    return SubprocessExecutor(DATA_DIR)
 
 
-DATASETS = _build_datasets()
+def _make_researcher(llm: LLMClient, *, reconcile: bool) -> Autoresearcher:
+    return Autoresearcher(_data_source(), llm, _executor(),
+                          explore_model=MODEL, verify_model=MODEL, reconcile=reconcile)
 
 
-def _count_matrix() -> pd.DataFrame:
-    """Dense samples × ASV read-count matrix from counts.json.gz."""
-    c = _rj("counts")
-    samples, asvs = c["samples"], c["asvs"]
-    m = np.zeros((len(samples), len(asvs)), dtype=float)
-    for s, a, cnt, _rel in c["data"]:
-        m[s, a] = cnt
-    return pd.DataFrame(m, index=samples, columns=asvs)
-
-
-COUNTS = _count_matrix()
-
-
-def _tax_df() -> pd.DataFrame:
-    """ASV → taxonomic rank table (Domain..Genus), aligned to COUNTS columns.
-    Lets the agent group abundances by taxon, split prokaryote vs eukaryote, and
-    screen for named contaminants."""
-    tax = _rj("taxonomy") or {}
-    _db, body = next(iter(tax.items()), ("none", {}))
-    levels, assign = body.get("levels", []), body.get("assignments", {})
-    df = pd.DataFrame.from_dict({a: dict(zip(levels, lin)) for a, lin in assign.items()}, orient="index")
-    return df.reindex(columns=levels)
-
-
-def _samples_df() -> pd.DataFrame:
-    """Per-sample metadata (library_name, collection_date, precomputed x/y, etc.)."""
-    sm = _rj("samples") or []
-    df = pd.DataFrame(sm)
-    return df.set_index("id") if "id" in df.columns else df
-
-
-TAX_DF = _tax_df()
-SAMPLES_META = _samples_df()
-
-
-def _navigate(path):
-    cur = DATASETS
-    for part in path.split("."):
-        if isinstance(cur, dict) and part in cur:
-            cur = cur[part]
-        elif isinstance(cur, list) and part.lstrip("-").isdigit() and int(part) < len(cur):
-            cur = cur[int(part)]
-        else:
-            return False, None
-    return True, cur
-
-
-# ── Analysis execution: isolation ─────────────────────────────────────────────
-# In PRODUCTION the agent's analysis cells run as Marimo notebooks INSIDE the
-# omc-session container, which is the real jail: the omc-sessions bridge DROPs all
-# outbound except the portal LLM proxy (session/setup-network.sh, enable_icc=false),
-# /data is a READ-ONLY squashfuse mount, and the container is capped at 2g/1cpu and
-# is ephemeral (portal/app/sessions.py). That already provides network isolation,
-# read-only data, and resource limits.
-#
-# THIS harness, however, runs standalone on the dev host — no container — so it
-# approximates that boundary with a separate python process: CPU + memory rlimits,
-# a wall-clock timeout, and network disabled (trusted imports load first, then the
-# socket is cut before the cell runs). The dev-host filesystem is NOT confined here,
-# so the harness is for trusted local benchmarking over vetted pipeline outputs; the
-# container is what confines untrusted execution in production.
-_CHILD_RUNNER = r'''
-import os, sys, json, gzip, resource
-resource.setrlimit(resource.RLIMIT_CPU, (25, 25))          # ~25s CPU
-try:  # generous virtual-address cap — numpy/BLAS reserve a lot even when RSS is small
-    resource.setrlimit(resource.RLIMIT_AS, (8 * 1024**3, 8 * 1024**3))
-except (ValueError, OSError):
-    pass
-DATA = os.environ["EXPLORER_DATA_DIR"]
-def _rj(name):
-    for p in (os.path.join(DATA, name + ".json"), os.path.join(DATA, name + ".json.gz")):
-        if os.path.exists(p):
-            op = gzip.open if p.endswith(".gz") else open
-            with op(p, "rt") as f:
-                return json.load(f)
-    return None
-# Trusted imports FIRST (ssl, loaded transitively, subclasses socket.socket) —
-# only after they're loaded do we disable the network for the model's code.
-import numpy as np, pandas as pd
-from scipy.spatial.distance import pdist, squareform, braycurtis
-from scipy.stats import entropy, pearsonr, spearmanr, kruskal, mannwhitneyu
-from sklearn.decomposition import PCA
-_c = _rj("counts"); counts = None
-if _c:
-    _m = np.zeros((len(_c["samples"]), len(_c["asvs"])))
-    for _s, _a, _n, _r in _c["data"]:
-        _m[_s, _a] = _n
-    counts = pd.DataFrame(_m, index=_c["samples"], columns=_c["asvs"])
-_t = _rj("taxonomy") or {}
-_db, _body = next(iter(_t.items()), ("none", {}))
-_lv = _body.get("levels", [])
-tax = pd.DataFrame.from_dict({a: dict(zip(_lv, l)) for a, l in _body.get("assignments", {}).items()},
-                            orient="index").reindex(columns=_lv)
-meta = pd.DataFrame(_rj("samples") or [])
-meta = meta.set_index("id") if "id" in meta.columns else meta
-import socket
-def _no_net(*a, **k):
-    raise OSError("network disabled in analysis sandbox")
-socket.socket = _no_net; socket.create_connection = _no_net; socket.getaddrinfo = _no_net
-def _j(v, d=0):
-    if d > 4: return str(v)
-    if isinstance(v, (np.floating, np.integer)): return round(float(v), 4)
-    if isinstance(v, float): return round(v, 4)
-    if isinstance(v, np.ndarray): return _j(v.tolist(), d + 1)
-    if isinstance(v, dict): return {str(k): _j(x, d + 1) for k, x in list(v.items())[:50]}
-    if isinstance(v, (list, tuple)): return [_j(x, d + 1) for x in list(v)[:50]]
-    if isinstance(v, (pd.Series, pd.DataFrame)): return _j(v.to_dict(), d + 1)
-    return v
-_ns = dict(np=np, pd=pd, counts=counts, tax=tax, meta=meta, pdist=pdist, squareform=squareform,
-           braycurtis=braycurtis, entropy=entropy, pearsonr=pearsonr, spearmanr=spearmanr,
-           kruskal=kruskal, mannwhitneyu=mannwhitneyu, PCA=PCA)
-try:
-    exec(sys.stdin.read(), _ns)
-    print(json.dumps({"__ok__": _j(_ns["result"])} if "result" in _ns
-                     else {"__err__": "code did not set a `result` variable"}))
-except Exception as e:
-    print(json.dumps({"__err__": f"{type(e).__name__}: {e}"}))
-'''
-
-
-def _run_code(code: str, timeout: int = 30):
-    """Run model-written analysis code in a resource-limited subprocess. Returns
-    (ok, result_or_error). Data is loaded from OMC_BENCH_DATA inside the child, so
-    the same code re-runs deterministically at verification time."""
-    try:
-        p = subprocess.run(
-            [sys.executable, "-c", _CHILD_RUNNER], input=code, text=True,
-            capture_output=True, timeout=timeout,
-            env={**os.environ, "EXPLORER_DATA_DIR": str(DATA_DIR),
-                 # single-threaded BLAS: deterministic + far smaller virtual footprint
-                 "OMP_NUM_THREADS": "1", "OPENBLAS_NUM_THREADS": "1", "MKL_NUM_THREADS": "1"},
-        )
-    except subprocess.TimeoutExpired:
-        return False, f"timeout >{timeout}s"
-    lines = (p.stdout or "").strip().splitlines()
-    try:
-        r = json.loads(lines[-1]) if lines else {}
-    except json.JSONDecodeError:
-        return False, ((p.stderr or p.stdout or "no output").strip().splitlines() or ["error"])[-1][:200]
-    return (True, r["__ok__"]) if "__ok__" in r else (False, r.get("__err__", "error"))
-
-
-def _jsonify(v, depth=0):
-    if depth > 4:
-        return str(v)
-    if isinstance(v, (np.floating, np.integer)):
-        return round(float(v), 4)
-    if isinstance(v, float):
-        return round(v, 4)
-    if isinstance(v, (np.ndarray,)):
-        return _jsonify(v.tolist(), depth + 1)
-    if isinstance(v, dict):
-        return {str(k): _jsonify(x, depth + 1) for k, x in list(v.items())[:50]}
-    if isinstance(v, (list, tuple)):
-        return [_jsonify(x, depth + 1) for x in list(v)[:50]]
-    if isinstance(v, (pd.Series, pd.DataFrame)):
-        return _jsonify(v.to_dict(), depth + 1)
-    return v
-
-
-def _flatten_numbers(v, acc):
-    if isinstance(v, bool):
-        return
-    if isinstance(v, (int, float)):
-        acc.append(float(v))
-    elif isinstance(v, dict):
-        for x in v.values():
-            _flatten_numbers(x, acc)
-    elif isinstance(v, (list, tuple)):
-        for x in v:
-            _flatten_numbers(x, acc)
-
-
-# ── DAG state ─────────────────────────────────────────────────────────────────
-COMPUTATIONS = {}  # id -> {label, code, result}
-LEDGER = []        # claim dicts
-AGENDA = []        # investigation worklist: {id, question, rationale, status, parent}
-
-
-def _current_investigation():
-    """The investigation being worked (first in-progress, else first pending)."""
-    for st in ("in_progress", "pending"):
-        for a in AGENDA:
-            if a["status"] == st:
-                return a["id"]
-    return None
-
-
-TOOLS = [
-    {"type": "function", "function": {
-        "name": "propose_agenda",
-        "description": ("FIRST STEP. Propose the analyses / hypothesis tests worth running on this "
-                        "amplicon dataset — the things a curious microbial ecologist would actually "
-                        "test. Be comprehensive and go beyond the obvious summary stats."),
-        "parameters": {"type": "object", "properties": {
-            "items": {"type": "array", "items": {"type": "object", "properties": {
-                "question": {"type": "string", "description": "the analysis/hypothesis, e.g. 'Do samples cluster in ordination, and which taxa drive the separation?'"},
-                "rationale": {"type": "string", "description": "why it matters ecologically"}},
-                "required": ["question"]}}},
-            "required": ["items"]}}},
-    {"type": "function", "function": {
-        "name": "get_agenda",
-        "description": "See the current agenda and each item's status (pending/in_progress/done).",
-        "parameters": {"type": "object", "properties": {}}}},
-    {"type": "function", "function": {
-        "name": "add_followup",
-        "description": ("Recurse: when a result is surprising or opens a deeper question, add a "
-                        "follow-up investigation (e.g. ordination shows structure → which taxa drive "
-                        "it → are they contaminants or real signal?). This is how you go deeper."),
-        "parameters": {"type": "object", "properties": {
-            "question": {"type": "string"}, "rationale": {"type": "string"}},
-            "required": ["question"]}}},
-    {"type": "function", "function": {
-        "name": "mark_done",
-        "description": "Mark the current investigation finished; move to the next agenda item.",
-        "parameters": {"type": "object", "properties": {}}}},
-    {"type": "function", "function": {
-        "name": "get_dataset",
-        "description": "Load a named summary dataset's contents (list_datasets to see names).",
-        "parameters": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}},
-    {"type": "function", "function": {
-        "name": "list_datasets",
-        "description": "List available summary datasets.",
-        "parameters": {"type": "object", "properties": {}}}},
-    {"type": "function", "function": {
-        "name": "run_analysis",
-        "description": ("Run Python to compute anything the summaries lack. In scope: `counts` "
-                        "(samples×ASV read-count DataFrame), `tax` (ASV×rank Domain..Genus — join to "
-                        "counts to work at taxon level or split Bacteria/Archaea vs Eukaryota), `meta` "
-                        "(per-sample metadata incl. library_name, collection_date, x/y). Helpers: np, "
-                        "pd, pdist, squareform, braycurtis, entropy, pearsonr, spearmanr, kruskal, "
-                        "mannwhitneyu, PCA. Code MUST assign to `result`. Compute before you claim."),
-        "parameters": {"type": "object", "properties": {
-            "label": {"type": "string"}, "code": {"type": "string", "description": "Python that sets `result`"}},
-            "required": ["label", "code"]}}},
-    {"type": "function", "function": {
-        "name": "record_claim",
-        "description": ("Record ONE verifiable claim from the current investigation. Cite antecedents "
-                        "(data paths and/or computation ids) so it can be re-checked. Prefer insight "
-                        "(patterns, relationships, anomalies) over restating summary numbers."),
-        "parameters": {"type": "object", "properties": {
-            "statement": {"type": "string"},
-            "value": {"type": "string", "description": "the exact supporting value"},
-            "antecedents": {"type": "array", "items": {"type": "string"}},
-            "kind": {"type": "string", "enum": ["observation", "pattern", "anomaly", "quality_caveat"]}},
-            "required": ["statement", "value", "antecedents"]}}},
-]
-
-
-def _exec_tool(name, args):
-    if name == "propose_agenda":
-        for it in args.get("items", [])[:20]:
-            AGENDA.append({"id": f"a{len(AGENDA) + 1}", "question": it.get("question", ""),
-                           "rationale": it.get("rationale", ""), "status": "pending", "parent": None})
-        if AGENDA:
-            AGENDA[0]["status"] = "in_progress"
-        return {"agenda": [{"id": a["id"], "question": a["question"], "status": a["status"]} for a in AGENDA]}
-    if name == "get_agenda":
-        return {"agenda": [{"id": a["id"], "question": a["question"], "status": a["status"],
-                            "parent": a["parent"]} for a in AGENDA]}
-    if name == "add_followup":
-        parent = _current_investigation()
-        AGENDA.append({"id": f"a{len(AGENDA) + 1}", "question": args.get("question", ""),
-                       "rationale": args.get("rationale", ""), "status": "pending", "parent": parent})
-        return {"added": AGENDA[-1]["id"], "parent": parent, "pending": sum(a["status"] == "pending" for a in AGENDA)}
-    if name == "mark_done":
-        cur = _current_investigation()
-        for a in AGENDA:
-            if a["id"] == cur:
-                a["status"] = "done"
-        nxt = _current_investigation()
-        for a in AGENDA:
-            if a["id"] == nxt and a["status"] == "pending":
-                a["status"] = "in_progress"
-        pend = sum(a["status"] in ("pending", "in_progress") for a in AGENDA)
-        return {"done": cur, "now": nxt, "remaining": pend}
-    if name == "list_datasets":
-        return {"datasets": list(DATASETS), "note": "use run_analysis with `counts`/`tax`/`meta` for real tests"}
-    if name == "get_dataset":
-        d = DATASETS.get(args.get("name"))
-        return d if d is not None else {"error": "unknown", "available": list(DATASETS)}
-    if name == "run_analysis":
-        ok, res = _run_code(args.get("code", ""))
-        if not ok:
-            return {"ok": False, "error": res}
-        cid = f"c{len(COMPUTATIONS) + 1}"
-        COMPUTATIONS[cid] = {"label": args.get("label", cid), "code": args.get("code", ""), "result": res}
-        return {"ok": True, "computation_id": cid, "result": res}
-    if name == "record_claim":
-        claim = {"id": f"k{len(LEDGER) + 1}", "statement": args.get("statement", ""),
-                 "value": str(args.get("value", "")), "antecedents": _norm_antecedents(args.get("antecedents")),
-                 "kind": args.get("kind", "observation"), "investigation": _current_investigation()}
-        LEDGER.append(claim)
-        return {"recorded": True, "claim_id": claim["id"], "n_claims": len(LEDGER)}
-    return {"error": f"unknown tool {name}"}
-
-
-EXPLORE_SYSTEM = """You are a curious microbial ecologist investigating a 16S/18S amplicon
-dataset. Your job is not to restate summary statistics — it is to TEST HYPOTHESES and find
-PATTERNS, RELATIONSHIPS, and ANOMALIES a scientist would care about, then ground each in a
-re-runnable computation.
-
-Work systematically and recursively:
-1. FIRST call propose_agenda with the analyses/hypothesis tests worth running here — the
-   standard microbial-ecology toolkit AND less obvious ideas. Think across: alpha diversity
-   (richness, Shannon, Simpson, Pielou evenness) and its dependence on sequencing depth;
-   dominance and the rare biosphere; beta-diversity structure (Bray-Curtis/Jaccard,
-   ordination) and WHICH taxa drive it; differential abundance / indicator taxa between
-   sample groups; co-occurrence; the prokaryote-vs-eukaryote split (use `tax` Domain);
-   core vs transient taxa (prevalence); and a contamination screen for known kit/reagent
-   genera (e.g. Ralstonia, Bradyrhizobium, Cutibacterium, Pelomonas, Delftia).
-2. Work the agenda item by item. For each: run_analysis over `counts`/`tax`/`meta` to test
-   it, then record_claim(s) with the exact value(s) and antecedents. mark_done and move on.
-3. RECURSE: whenever a result is surprising or opens a question, add_followup — that is how
-   you go deeper (a cluster in ordination → its driver taxa → are they contamination?).
-4. Prefer claims of kind "pattern" or "anomaly" (an insight) over "observation" (a restated
-   number). Be honest: record quality_caveat for depth bias, low evenness, contamination,
-   or anything that undermines a result. Never claim a number you did not compute.
-
-KNOW WHAT THE FIELDS MEAN, then think critically about the data:
-- `meta['x']`/`meta['y']` are PRECOMPUTED ORDINATION coordinates, not geographic lat/lon.
-- `meta['collection_date']` is often a database record-creation date, not a verified sampling
-  date. Treat SRA metadata labels — including the stated amplicon target — as unverified: they
-  are frequently wrong.
-- A named test (Mantel, PERMANOVA, ...) must be the test you actually ran; don't upgrade a
-  plain correlation to a named test.
-- Sanity-check the data against the stated context in get_dataset('study'). Don't invent
-  effects the data doesn't support; equally, don't accept a label the data contradicts —
-  where they disagree, the contradiction is itself a grounded finding worth recording.
-
-Keep going until the agenda (including follow-ups) is worked through, then reply DONE."""
-
-
-def explore(client, max_steps=48):
-    messages = [{"role": "system", "content": EXPLORE_SYSTEM},
-                {"role": "user", "content": "Propose your agenda of microbial-ecology tests, then work through it, recursing where it gets interesting."}]
-    for step in range(max_steps):
-        r = client.chat.completions.create(model=MODEL, messages=messages, tools=TOOLS,
-                                           tool_choice="auto", temperature=0.25, max_tokens=2500)
-        msg = r.choices[0].message
-        if not msg.tool_calls:
-            content, _ = _visible_and_finish(r)
-            active = [a for a in AGENDA if a["status"] in ("pending", "in_progress")]
-            if "DONE" in (content or "").upper() and not active:
-                break
-            if "DONE" in (content or "").upper() and active:
-                messages.append({"role": "user", "content": f"{len(active)} agenda items remain — work the next one (get_agenda)."})
-                continue
-            messages.append({"role": "user", "content": "Continue with the current investigation, or mark_done and take the next."})
-            continue
-        messages.append({"role": "assistant", "content": msg.content or "",
-                         "tool_calls": [tc.model_dump() for tc in msg.tool_calls]})
-        for tc in msg.tool_calls:
-            try:
-                args = json.loads(tc.function.arguments or "{}")
-            except json.JSONDecodeError:
-                args = {}
-            result = _exec_tool(tc.function.name, args)
-            label = args.get("label") or args.get("name") or args.get("question") or (args.get("statement") or "")[:40]
-            print(f"  [{step}] {tc.function.name}({str(label)[:46]}) -> {str(result)[:70]}", flush=True)
-            messages.append({"role": "tool", "tool_call_id": tc.id,
-                             "content": json.dumps(result, default=str)[:3500]})
-    # If we hit the step cap with work outstanding, DO NOT pretend it finished:
-    # the current item was interrupted (not done), and pending items stay pending.
-    # Returns True only when the agenda was actually worked through.
-    for a in AGENDA:
-        if a["status"] == "in_progress":
-            a["status"] = "interrupted"
-    return not any(a["status"] in ("pending", "in_progress", "interrupted") for a in AGENDA)
-
-
-# ── Verification: re-derive every claim ───────────────────────────────────────
-def _norm_antecedents(x):
-    """Antecedents as a clean list of tokens. Some models (e.g. Sonnet) return the
-    array arg as a delimited STRING ('c2, c3; path') instead of a JSON list — split
-    it rather than iterating it character-by-character."""
-    if isinstance(x, list):
-        items = x
-    elif isinstance(x, str):
-        items = re.split(r"[;,]", x)
-    else:
-        items = []
-    return [t.strip() for t in items if t and t.strip()]
-
-
-def _nums(s):
-    """Every genuine quantity in a string. The lookbehind blocks numbers embedded in
-    an alphanumeric token — not just glued to a letter ('PC1') but mid-token digit
-    runs like 'SRR38966955' (block preceded-by letter/digit/dot) — so accession IDs
-    aren't mistaken for claimed values. Handles ranges ('19-98') and thousands commas."""
-    return [float(x.replace(",", ""))
-            for x in re.findall(r"(?<![A-Za-z0-9.])\d[\d,]*(?:\.\d+)?", str(s))]
-
-
-def _close(x, n):
-    return abs(x - n) < 0.05 * max(abs(n), 1)
-
-
-def _match_num(x, cands):
-    """How (if at all) claim number x is backed by the antecedent numbers `cands`.
-
-    Verification must re-derive x in its STATED representation, not demand a literal
-    match: a value can be the same truth in different units (fraction<->percent) or
-    a simple derivation of the inputs (difference, ratio). Pairwise derivation is
-    limited to small summary sources so it can't spuriously fire on big result sets.
-    """
-    for n in cands:
-        if _close(x, n):
-            return "direct"
-        if _close(x, n * 100):
-            return "x100"          # claim in %, source a fraction
-        if n and _close(x, n / 100):
-            return "/100"          # claim a fraction, source in %
-    if len(cands) <= 12:            # derived from a summary (e.g. 73 = 84 - 11)
-        for a in cands:
-            for b in cands:
-                if a is b:
-                    continue
-                for val, tag in ((a - b, "diff"), (a + b, "sum"),
-                                 (100 * a / b if b else None, "pct"),
-                                 (100 * (b - a) / b if b else None, "pct")):
-                    if val is not None and _close(x, val):
-                        return "derived:" + tag
-    return None
-
-
-RECONCILE_SYSTEM = """You are a skeptical verification auditor. You are given a CLAIM and the
-INDEPENDENT EVIDENCE that was re-executed from the raw data (computation results and data
-values). Decide whether the evidence genuinely supports the claim's quantitative content.
-
-- Judge only against the evidence shown — never from prior knowledge.
-- Allow equivalent representations: unit conversions (a fraction vs a percent), values that
-  are a simple derivation of the evidence (e.g. a difference or ratio), and ranges.
-- IGNORE tokens that are identifiers, not quantities (sample accessions like SRR38966955).
-- If the claim packs several numbers, it is SUPPORTED only if every quantitative number is
-  backed; if some are and some aren't, say PARTIAL and list which fail.
-- Default to UNSUPPORTED when the evidence does not clearly back a number. Be strict.
-
-Reply with exactly one line 'VERDICT: SUPPORTED|PARTIAL|UNSUPPORTED' then one sentence why."""
-
-
-def _evidence_for(claim) -> str:
-    """The deterministic evidence block for a claim: re-executed computation results
-    and re-read data values for each antecedent. This is what the reconciler judges
-    against — not memory."""
-    parts = []
-    for ant in claim["antecedents"]:
-        if ant in COMPUTATIONS:
-            good, res = _run_code(COMPUTATIONS[ant]["code"])
-            parts.append(f"[{ant}] {COMPUTATIONS[ant]['label']} (re-executed) = "
-                         + (json.dumps(res)[:600] if good else "ERROR"))
-        else:
-            found, val = _navigate(ant)
-            parts.append(f"[{ant}] = {json.dumps(val)[:300] if found else 'NOT FOUND'}")
-    return "\n".join(parts)
-
-
-def reconcile_claim(client, claim) -> dict:
-    """Model adjudication of a claim against its re-executed evidence (issue #29).
-    Only invoked on a deterministic miss. Returns {verdict, reasoning}."""
-    user = (f"CLAIM: {claim['statement']}\nCLAIMED VALUE: {claim['value']}\n\n"
-            f"INDEPENDENT EVIDENCE (re-executed from raw data):\n{_evidence_for(claim)}")
-    from ai.llm_client import chat
-    resp = chat(client, RECONCILE_SYSTEM, user, model=MODEL, max_tokens=4000, temperature=0.0)
-    m = re.search(r"VERDICT:\s*(SUPPORTED|PARTIAL|UNSUPPORTED)", resp.upper())
-    return {"verdict": m.group(1).lower() if m else "unsupported", "reasoning": resp.strip()[:400]}
-
-
-def verify(client=None):
-    """Re-derive each claim from its antecedents (data re-read; computations
-    re-EXECUTED). Deterministic first; a true claim is never marked refuted for a
-    representation mismatch. If `client` is given, a deterministic MISS escalates to
-    a skeptical model reconciliation against the same re-executed evidence — robust
-    on the hard cases, and labeled so it's clear which claims leaned on judgment."""
-    for c in LEDGER:
-        c["antecedents"] = _norm_antecedents(c["antecedents"])  # tolerate string-form ledgers
-        claim_nums = _nums(c["value"])
-        candidates, strvals, checked = [], [], []
-        for ant in c["antecedents"]:
-            if ant in COMPUTATIONS:
-                good, res = _run_code(COMPUTATIONS[ant]["code"])  # re-execute stored code
-                if good:
-                    _flatten_numbers(res, candidates)
-                checked.append(f"{ant}:{'run' if good else 'err'}")
-            else:  # data path
-                found, actual = _navigate(ant)
-                if found:
-                    _flatten_numbers(actual, candidates)
-                    strvals.append(str(actual))
-                checked.append(f"{ant}:{'ok' if found else 'nopath'}")
-
-        have_evidence = bool(candidates or strvals)
-        if claim_nums:
-            methods = [_match_num(x, candidates) for x in claim_nums]
-            ok = all(methods) if candidates else None
-            c["method"] = ",".join(m for m in methods if m) or None
-        else:  # non-numeric claim (e.g. a database name)
-            ok = any(c["value"].strip().lower() in s.lower() for s in strvals) if strvals else None
-        c["verdict"] = "verified" if ok else ("unverifiable" if (ok is None or not have_evidence) else "refuted")
-        c["checked"] = checked
-        # Escalate deterministic misses to a skeptical model reconciliation against
-        # the SAME re-executed evidence (labeled, so judgment-backed claims are visible).
-        if c["verdict"] != "verified" and client is not None and have_evidence:
-            rec = reconcile_claim(client, c)
-            c["reconcile"] = rec
-            if rec["verdict"] == "supported":
-                c["verdict"], c["method"] = "verified", "reconciled"
-
-
-def _supported_results_data():
+def _supported_results_data(computations, ledger):
     """Ground-truth for check_numbers_supported = raw pipeline data PLUS verified
     computed values (a verified computation IS support). Includes fraction→percent
     forms so '0.4311' also backs a '43.1%' claim."""
     fx = load_fixture()
     forms = []
-    for comp in COMPUTATIONS.values():
+    for comp in computations.values():
         nums = []
         _flatten_numbers(comp["result"], nums)
         for n in nums:
             for v in (n, n * 100):
                 forms += [round(v, 4), round(v, 2), round(v, 1)]
-    return {"pipeline": fx, "verified_claims": [c["value"] for c in LEDGER if c.get("verdict") == "verified"],
+    return {"pipeline": fx, "verified_claims": [c["value"] for c in ledger if c.get("verdict") == "verified"],
             "computed_support": sorted(set(forms))}
 
 
-# ── DAG export ────────────────────────────────────────────────────────────────
-def build_dag():
-    nodes, edges, seen = [], [], set()
-
-    def add(nid, **kw):
-        if nid not in seen:
-            seen.add(nid)
-            nodes.append({"id": nid, **kw})
-
-    for cid, comp in COMPUTATIONS.items():
-        add(cid, type="computation", label=comp["label"])
-    for c in LEDGER:
-        add(c["id"], type="claim", label=c["statement"][:60], verdict=c.get("verdict"), kind=c["kind"])
-        for ant in c["antecedents"]:
-            if ant in COMPUTATIONS:
-                edges.append({"from": ant, "to": c["id"]})
-            else:
-                add(ant, type="data", label=ant)
-                edges.append({"from": ant, "to": c["id"]})
-    return {"nodes": nodes, "edges": edges}
+def _write_ledger(ar: Autoresearcher, completed: bool, done: int):
+    (OUT / "claims_ledger.json").write_text(json.dumps(
+        {"claims": ar.ledger, "computations": ar.computations, "agenda": ar.agenda,
+         "run": {"completed": completed, "investigations_done": done,
+                 "investigations_total": len(ar.agenda)}}, indent=2, default=str) + "\n")
 
 
-def dag_mermaid(dag):
-    sty = {"verified": "fill:#2e7d32,color:#fff", "refuted": "fill:#c62828,color:#fff",
-           "unverifiable": "fill:#f9a825,color:#000", "computation": "fill:#1565c0,color:#fff",
-           "data": "fill:#455a64,color:#fff"}
-    lines = ["```mermaid", "graph LR"]
-    for n in dag["nodes"]:
-        lbl = n["label"].replace('"', "'")
-        shape = f'[["{lbl}"]]' if n["type"] == "computation" else (
-            f'("{lbl}")' if n["type"] == "data" else f'["{lbl}"]')
-        lines.append(f'  {n["id"]}{shape}')
-        cls = n.get("verdict") if n["type"] == "claim" else n["type"]
-        if cls in sty:
-            lines.append(f'  style {n["id"]} {sty[cls]}')
-    for e in dag["edges"]:
-        lines.append(f'  {e["from"]} --> {e["to"]}')
-    lines.append("```")
-    return "\n".join(lines)
+def _write_dag(ar: Autoresearcher, verified: int, status: str):
+    dag = ar.build_dag()
+    (OUT / "claims_dag.json").write_text(json.dumps(dag, indent=2, default=str) + "\n")
+    (OUT / "claims_dag.md").write_text(
+        f"# Claim provenance DAG ({MODEL}) — {status}\n\n{verified}/{len(ar.ledger)} claims verified · "
+        f"{len(ar.computations)} computations\n\nLegend: 🟩 verified · 🟥 refuted · 🟨 unverifiable · "
+        f"🟦 computation · ⬛ data\n\n{dag_mermaid(dag)}\n")
 
 
-WRITE_SYSTEM = """Scientific writing assistant for microbial ecology. Write a Results section
-using ONLY the verified claims provided — every number must come from a claim. Do not add
-findings not in the claims. Report quality caveats plainly and politely. Past tense,
-objective, no interpretation. Synthesize into flowing prose (not a bullet list). Reference
-Figure/Table where natural."""
-
-
-def write_results(client, verified):
-    claims_txt = "\n".join(f"- [{c['kind']}] {c['statement']} (value={c['value']})" for c in verified)
-    study = (f"Study: {STUDY_GROUNDED['title']} — {STUDY_GROUNDED['study_name']} "
-             f"({STUDY_GROUNDED['bioproject']}), {STUDY_GROUNDED['platform']}.")
-    msgs = [{"role": "system", "content": WRITE_SYSTEM},
-            {"role": "user", "content": f"{study}\n\nVERIFIED CLAIMS:\n{claims_txt}\n\nWrite the Results section."}]
-    for mt in (6000, 12000):
-        content, _ = _visible_and_finish(
-            client.chat.completions.create(model=MODEL, messages=msgs, temperature=0.4, max_tokens=mt))
-        if content.strip():
-            return content
-    return content
-
-
-def reverify_saved(client=None):
+async def _reverify_async(llm):
     """Re-run verification (and rebuild the DAG) on the saved ledger. With no client
     it is purely deterministic (no model — fully reproducible); with a client, a
     deterministic miss escalates to skeptical model reconciliation."""
     saved = json.loads((OUT / "claims_ledger.json").read_text())
-    LEDGER[:] = saved["claims"]
-    COMPUTATIONS.clear(); COMPUTATIONS.update(saved["computations"])
-    AGENDA[:] = saved.get("agenda", [])
-    verify(client)
-    done = sum(a["status"] == "done" for a in AGENDA)
-    completed = bool(AGENDA) and all(a["status"] == "done" for a in AGENDA)
-    (OUT / "claims_ledger.json").write_text(json.dumps(
-        {"claims": LEDGER, "computations": COMPUTATIONS, "agenda": AGENDA,
-         "run": {"completed": completed, "investigations_done": done,
-                 "investigations_total": len(AGENDA)}}, indent=2, default=str) + "\n")
-    dag = build_dag()
-    (OUT / "claims_dag.json").write_text(json.dumps(dag, indent=2, default=str) + "\n")
-    verified_claims = [c for c in LEDGER if c["verdict"] == "verified"]
+    reconcile = llm is not None
+    ar = Autoresearcher.from_snapshot(saved, _data_source(), llm or LLMClient(None, MODEL),
+                                      _executor(), explore_model=MODEL, verify_model=MODEL,
+                                      reconcile=reconcile)
+    await ar.verify()
+    done = sum(a["status"] == "done" for a in ar.agenda)
+    completed = bool(ar.agenda) and all(a["status"] == "done" for a in ar.agenda)
+    _write_ledger(ar, completed, done)
+    verified_claims = [c for c in ar.ledger if c["verdict"] == "verified"]
     verified = len(verified_claims)
-    status = "complete" if completed else f"INCOMPLETE ({done}/{len(AGENDA)} investigations)"
-    (OUT / "claims_dag.md").write_text(
-        f"# Claim provenance DAG ({MODEL}) — {status}\n\n{verified}/{len(LEDGER)} claims verified · "
-        f"{len(COMPUTATIONS)} computations\n\nLegend: 🟩 verified · 🟥 refuted · 🟨 unverifiable · "
-        f"🟦 computation · ⬛ data\n\n{dag_mermaid(dag)}\n")
+    status = "complete" if completed else f"INCOMPLETE ({done}/{len(ar.agenda)} investigations)"
+    _write_dag(ar, verified, status)
     # With a client, regenerate the Results prose so the snapshot is coherent.
-    if client is not None and verified_claims:
+    if llm is not None and verified_claims:
         banner = "" if completed else (
-            f"> ⚠️ PRELIMINARY — {len(AGENDA) - done} of {len(AGENDA)} investigations outstanding; "
+            f"> ⚠️ PRELIMINARY — {len(ar.agenda) - done} of {len(ar.agenda)} investigations outstanding; "
             f"these Results are partial.\n\n")
-        text = write_results(client, verified_claims)
+        text = await ar.write_results(verified_claims)
         (OUT / "results_from_claims.md").write_text(
             f"# Results from claims ({MODEL}) — {status}\n\n{banner}"
-            f"_{verified}/{len(LEDGER)} verified · {len(COMPUTATIONS)} computations · "
-            f"{done}/{len(AGENDA)} investigations_\n\n{text}\n")
-    print(f"re-verified {verified}/{len(LEDGER)} claims (offline)")
-    for c in LEDGER:
+            f"_{verified}/{len(ar.ledger)} verified · {len(ar.computations)} computations · "
+            f"{done}/{len(ar.agenda)} investigations_\n\n{text}\n")
+    print(f"re-verified {verified}/{len(ar.ledger)} claims (offline)")
+    for c in ar.ledger:
         if c["verdict"] != "verified":
             print(f"    [{c['verdict']:12}] {c['id']} {c['statement'][:60]}")
         elif c.get("method") and c["method"] != "direct":
             print(f"    [verified:{c['method']:14}] {c['id']} {c['statement'][:52]}")
+
+
+def reverify_saved(client=None):
+    """Sync entry point (used by run_real_sample.py): re-verify the saved ledger.
+    ``client`` is an ``LLMClient`` or None."""
+    asyncio.run(_reverify_async(client))
+
+
+async def _main_async(llm: LLMClient):
+    print(f"model: {MODEL} @ {BASE_URL}")
+    print("=== EXPLORE (agenda-driven, recursive) ===")
+    t0 = time.time()
+    ar = _make_researcher(llm, reconcile=True)
+    completed = await ar.explore()
+    await ar.verify()  # deterministic first; escalate misses to skeptical model reconciliation
+    done = sum(a["status"] == "done" for a in ar.agenda)
+    outstanding = [a for a in ar.agenda if a["status"] != "done"]
+    print(f"\n  agenda ({done}/{len(ar.agenda)} investigations done"
+          f"{'' if completed else f' — INCOMPLETE, {len(outstanding)} outstanding'}):")
+    for a in ar.agenda:
+        tag = "  └─" if a["parent"] else "•"
+        print(f"    {tag} [{a['status']}] {a['id']}: {a['question'][:72]}")
+    print(f"\n  {len(ar.ledger)} claims, {len(ar.computations)} computations in {time.time()-t0:.0f}s")
+    for c in ar.ledger:
+        print(f"    [{c.get('verdict'):12}|{c.get('kind','?')[:7]:7}] {c['statement'][:60]}  (={c['value']})")
+
+    verified = [c for c in ar.ledger if c["verdict"] == "verified"]
+    status = "complete" if completed else f"INCOMPLETE ({done}/{len(ar.agenda)} investigations)"
+    banner = "" if completed else (
+        f"> ⚠️ PRELIMINARY — exploration stopped with {len(outstanding)} of {len(ar.agenda)} "
+        f"investigations outstanding ({', '.join(a['id'] for a in outstanding)}); "
+        f"these Results are partial.\n\n")
+    # One atomic snapshot: ledger, DAG, and prose written from the SAME run state.
+    _write_ledger(ar, completed, done)
+    _write_dag(ar, len(verified), status)
+
+    print("\n=== WRITE (verified claims only) ===")
+    text = await ar.write_results(verified)
+    unsupported = check_numbers_supported({"results": text}, results_data=_supported_results_data(
+        ar.computations, ar.ledger))
+    n_unsupported = sum(len(i["detail"].split("may be unsupported:")[1].split(","))
+                        for i in unsupported) if unsupported else 0
+    (OUT / "results_from_claims.md").write_text(
+        f"# Results from claims ({MODEL}) — {status}\n\n{banner}"
+        f"_{len(verified)}/{len(ar.ledger)} verified · {len(ar.computations)} computations · "
+        f"{n_unsupported} unsupported numbers · {done}/{len(ar.agenda)} investigations_\n\n{text}\n")
+    print(f"  {status}; verified {len(verified)}/{len(ar.ledger)}; {n_unsupported} unsupported numbers")
+    print(f"  -> claims_ledger.json, claims_dag.json, claims_dag.md, results_from_claims.md")
 
 
 def main():
@@ -740,54 +207,7 @@ def main():
         reverify_saved(client); return
     if not _ensure_model_loaded():
         print("load failed"); return
-    client = _client()
-    print(f"model: {MODEL} @ {BASE_URL}")
-
-    print("=== EXPLORE (agenda-driven, recursive) ===")
-    t0 = time.time()
-    completed = explore(client)
-    verify(client)  # deterministic first; escalate misses to skeptical model reconciliation
-    done = sum(a["status"] == "done" for a in AGENDA)
-    outstanding = [a for a in AGENDA if a["status"] != "done"]
-    print(f"\n  agenda ({done}/{len(AGENDA)} investigations done"
-          f"{'' if completed else f' — INCOMPLETE, {len(outstanding)} outstanding'}):")
-    for a in AGENDA:
-        tag = "  └─" if a["parent"] else "•"
-        print(f"    {tag} [{a['status']}] {a['id']}: {a['question'][:72]}")
-    print(f"\n  {len(LEDGER)} claims, {len(COMPUTATIONS)} computations in {time.time()-t0:.0f}s")
-    for c in LEDGER:
-        print(f"    [{c.get('verdict'):12}|{c.get('kind','?')[:7]:7}] {c['statement'][:60]}  (={c['value']})")
-
-    verified = [c for c in LEDGER if c["verdict"] == "verified"]
-    status = "complete" if completed else f"INCOMPLETE ({done}/{len(AGENDA)} investigations)"
-    banner = "" if completed else (
-        f"> ⚠️ PRELIMINARY — exploration stopped with {len(outstanding)} of {len(AGENDA)} "
-        f"investigations outstanding ({', '.join(a['id'] for a in outstanding)}); "
-        f"these Results are partial.\n\n")
-    # One atomic snapshot: ledger, DAG, and prose written from the SAME run state.
-    (OUT / "claims_ledger.json").write_text(json.dumps(
-        {"claims": LEDGER, "computations": COMPUTATIONS, "agenda": AGENDA,
-         "run": {"completed": completed, "investigations_done": done,
-                 "investigations_total": len(AGENDA)}}, indent=2, default=str) + "\n")
-    dag = build_dag()
-    (OUT / "claims_dag.json").write_text(json.dumps(dag, indent=2, default=str) + "\n")
-    (OUT / "claims_dag.md").write_text(
-        f"# Claim provenance DAG ({MODEL}) — {status}\n\n"
-        f"{len(verified)}/{len(LEDGER)} claims verified · {len(COMPUTATIONS)} computations\n\n"
-        f"Legend: 🟩 verified · 🟥 refuted · 🟨 unverifiable · 🟦 computation · ⬛ data\n\n"
-        f"{dag_mermaid(dag)}\n")
-
-    print("\n=== WRITE (verified claims only) ===")
-    text = write_results(client, verified)
-    unsupported = check_numbers_supported({"results": text}, results_data=_supported_results_data())
-    n_unsupported = sum(len(i["detail"].split("may be unsupported:")[1].split(","))
-                        for i in unsupported) if unsupported else 0
-    (OUT / "results_from_claims.md").write_text(
-        f"# Results from claims ({MODEL}) — {status}\n\n{banner}"
-        f"_{len(verified)}/{len(LEDGER)} verified · {len(COMPUTATIONS)} computations · "
-        f"{n_unsupported} unsupported numbers · {done}/{len(AGENDA)} investigations_\n\n{text}\n")
-    print(f"  {status}; verified {len(verified)}/{len(LEDGER)}; {n_unsupported} unsupported numbers")
-    print(f"  -> claims_ledger.json, claims_dag.json, claims_dag.md, results_from_claims.md")
+    asyncio.run(_main_async(_client()))
 
 
 if __name__ == "__main__":

--- a/tests/bench/results_explorer.py
+++ b/tests/bench/results_explorer.py
@@ -73,7 +73,7 @@ def _data_source() -> DirDataSource:
 
 
 def _executor() -> SubprocessExecutor:
-    """The DEV/offline jail: a resource-limited subprocess over the same data dir."""
+    """The DEV/offline sandbox: a resource-limited subprocess over the same data dir."""
     return SubprocessExecutor(DATA_DIR)
 
 

--- a/tests/bench/writings/claims_dag.md
+++ b/tests/bench/writings/claims_dag.md
@@ -1,6 +1,6 @@
-# Claim provenance DAG (qwen/qwen3.6-35b-a3b)
+# Claim provenance DAG (qwen/qwen3.6-35b-a3b) — INCOMPLETE (0/0 investigations)
 
-16/18 claims verified · 30 computations
+18/18 claims verified · 30 computations
 
 Legend: 🟩 verified · 🟥 refuted · 🟨 unverifiable · 🟦 computation · ⬛ data
 
@@ -113,9 +113,9 @@ graph LR
   k11["Mean pairwise Bray-Curtis dissimilarity between samples was "]
   style k11 fill:#2e7d32,color:#fff
   k12["PCA on log-transformed counts: PC1 explained 36.76% and PC2 "]
-  style k12 fill:#c62828,color:#fff
+  style k12 fill:#2e7d32,color:#fff
   k13["QUALITY CAVEAT: 73 of 84 samples (86.9%) were lost during de"]
-  style k13 fill:#c62828,color:#fff
+  style k13 fill:#2e7d32,color:#fff
   k14["QUALITY CAVEAT: 1 chloroplast ASV was detected in 3 samples "]
   style k14 fill:#2e7d32,color:#fff
   renorm_stats.chloroplast.n_asvs("renorm_stats.chloroplast.n_asvs")

--- a/tests/bench/writings/claims_ledger.json
+++ b/tests/bench/writings/claims_ledger.json
@@ -1415,5 +1415,11 @@
         "PC2": 0.1573
       }
     }
+  },
+  "agenda": [],
+  "run": {
+    "completed": false,
+    "investigations_done": 0,
+    "investigations_total": 0
   }
 }


### PR DESCRIPTION
Wires the claim-grounded autoresearch prototype (`tests/bench`) into the portal so an author can run it from the Results-review step, and produces a coherent, verifiable, provenance-tracked snapshot. Built with a multi-agent workflow (map → design → build → adversarial-review), then human-reviewed with the review findings fixed.

## Architecture (honors the hard constraints)
- **Agent loop runs server-side** (like `reviews.py`), via `resolve_llm(user)` — it orchestrates; it never runs model code on the host.
- **`run_analysis` model code runs INSIDE the `omc-session-{slug}` container** (`ContainerExecutor` → `docker exec`): the jail — outbound-dropped except the portal proxy, `/data` read-only squashfuse, 2g/1cpu, ephemeral. The **same child runner** is used at exploration and verification time, so deterministic re-execution is byte-identical.
- **LLM tool-calling passes straight through** the proxy (it forwards the raw body).
- **Offline bench harness preserved** — `python3 tests/bench/results_explorer.py --reverify` stays **18/18, model-free** (it now imports the shared `ai/autoresearch.py` core).

## What's here
- `ai/autoresearch.py` (core, injection-based: `DataSource` / `CodeExecutor` / `LLMClient`; the agenda loop, two-layer verify, DAG, Results writer).
- `portal/app/autoresearch.py` (SSE run route + provenance viewer; persistence to `interview_data['_autoresearch']`; optional `.omc/` PR).
- `portal/app/autoresearch_executor.py` (`ContainerExecutor`).
- `portal/templates/provenance.html` + `_autoresearch_trigger.html`.
- `config.py` `AUTORESEARCH_*` flags (**off by default**) + `explore`/`verify` role models.

## Adversarial-review findings — all fixed on this branch
1. **BLOCKER** — `ContainerExecutor` module was missing (the portal imported it → every run would `ImportError`). Created.
2. **XSS** — the viewer embedded model-generated JSON in a `<script>` via `| safe`; a `</script>` in a claim or `run_analysis` snippet could inject markup. Now escaped (`</>&`, U+2028/9) server-side.
3. **Event loop** — sync taxonomy/JSON reads ran inline on the portal loop; now pre-warmed via `asyncio.to_thread`.
4. **Grounding** (product request) — the `study` dataset now carries today's real `analysis_date` (`datetime.date.today()`) + a prompt line, so the agent judges dates correctly (a recent date isn't mistaken for "future", as Opus did without it).

## Gate (offline, automated)
`py_compile` + imports of all changed modules PASS; `import ai.autoresearch` / `import portal.app.autoresearch` / `import portal.app.autoresearch_executor` PASS; `--reverify` PASS (18/18); grep confirms **no model-code `exec`/`subprocess` on the portal side** outside the container executor.

## Needs live-deployment testing (no Docker/session infra in dev)
The container-exec path, the SSE stream end-to-end, session-container launch/`/data/viz/data` presence, and `.omc/` PR. Shipped **gated behind `AUTORESEARCH_ENABLED=false`** — enable on a deployment with completed `.sqsh` results to exercise the full flow.

Closes the prototype→product gap for #29. Related: #37 (per-sample primer sheet → agents), #39 (seed non-deterministic computations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)