### PR TITLE
autoresearch: fix prod data path + ship sci stack in session image

### DIFF
--- a/ai/autoresearch.py
+++ b/ai/autoresearch.py
@@ -526,9 +526,13 @@ def _rj(name):
 # Trusted imports FIRST (ssl, loaded transitively, subclasses socket.socket) —
 # only after they're loaded do we disable the network for the model's code.
 import numpy as np, pandas as pd
-from scipy.spatial.distance import pdist, squareform, braycurtis
-from scipy.stats import entropy, pearsonr, spearmanr, kruskal, mannwhitneyu
-from sklearn.decomposition import PCA
+try:  # scipy/sklearn are the analysis toolkit; if a sandbox lacks them, numpy/
+    # pandas analyses still run and only toolkit-using code errors per-call.
+    from scipy.spatial.distance import pdist, squareform, braycurtis
+    from scipy.stats import entropy, pearsonr, spearmanr, kruskal, mannwhitneyu
+    from sklearn.decomposition import PCA
+except ImportError:
+    pdist = squareform = braycurtis = entropy = pearsonr = spearmanr = kruskal = mannwhitneyu = PCA = None
 _c = _rj("counts"); counts = None
 if _c:
     _m = np.zeros((len(_c["samples"]), len(_c["asvs"])))

--- a/portal/app/autoresearch.py
+++ b/portal/app/autoresearch.py
@@ -110,13 +110,13 @@ async def _build_data_source(slug: str, study: dict):
 
     viz_dir = None
     for base in (sqsh_mount, Path(settings.local_download_path) / slug):
-        cand = Path(base) / "viz" / "data"
+        cand = Path(base) / "viz"
         if _dir_has_content(cand):
             viz_dir = cand
             break
     if viz_dir is None:
         raise RuntimeError(
-            "No pipeline viz data found (expected .../viz/data) — autoresearch "
+            "No pipeline viz data found (expected .../viz) — autoresearch "
             "requires completed pipeline results (.sqsh) for this submission.")
     return DirDataSource(viz_dir, study=study)
 

--- a/portal/app/autoresearch_executor.py
+++ b/portal/app/autoresearch_executor.py
@@ -7,7 +7,7 @@ the container is capped at 2g/1cpu and ephemeral (see ``portal/app/sessions.py``
 The child runner is the SAME ``_SUBPROCESS_RUNNER`` the dev/offline
 ``SubprocessExecutor`` uses (imported from ``ai.autoresearch``), so re-execution
 at verification time is byte-identical to exploration time — it reads the viz
-JSON from ``/data/viz/data`` (the ``.sqsh`` bind-mounted read-only) inside the
+JSON from ``/data/viz`` (the ``.sqsh`` bind-mounted read-only) inside the
 container and prints a single JSON line (``{"__ok__": ...}`` or ``{"__err__": ...}``).
 """
 from __future__ import annotations
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 # The submission's viz JSON inside the container: the .sqsh is bind-mounted
 # read-only at /data (sessions.py: -v {mount}:/data:ro), and the amplicon viz
-# lives under viz/data (matching the host path the DirDataSource reads).
-CONTAINER_DATA_DIR = "/data/viz/data"
+# JSON lives directly under viz/ (matching the host path the DirDataSource reads).
+CONTAINER_DATA_DIR = "/data/viz"
 
 
 class ContainerExecutor:

--- a/session/Dockerfile
+++ b/session/Dockerfile
@@ -9,6 +9,8 @@ RUN pip install --no-cache-dir \
     plotly \
     pandas \
     numpy \
+    scipy \
+    scikit-learn \
     openai \
     httpx
 


### PR DESCRIPTION
Bringing autoresearch live on prod against real `.sqsh` data surfaced three setup bugs:

1. **Data path** — pipeline writes viz JSON directly under `viz/`, but `_build_data_source` and `ContainerExecutor` both looked for `viz/data/` (empty on every submission). Fixed both to `viz/`.
2. **Session image missing sci stack** — the subprocess runner preamble imports `scipy` + `sklearn` (the toolkit it injects: braycurtis/PCA/spearmanr/entropy/...), but the session image only had numpy+pandas, so *every* `run_analysis` crashed on import. Added `scipy` + `scikit-learn` to `session/Dockerfile` (needs image rebuild).
3. **Runner robustness** — wrapped the scipy/sklearn imports so a sandbox lacking them degrades to numpy/pandas analyses instead of failing all analysis.

Validated: syntax + offline `--reverify` gate green; live container path verified separately after image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)