### PR TITLE
autoresearch: keep-digging continue + rename provenance→findings + per-user max_steps

### DIFF
--- a/ai/autoresearch.py
+++ b/ai/autoresearch.py
@@ -713,14 +713,47 @@ class Autoresearcher:
         return {"error": f"unknown tool {name}"}
 
     # -- explore ----------------------------------------------------------------
-    async def explore(self) -> bool:
+    def _resume_briefing(self) -> str:
+        """User message that re-orients the model when CONTINUING a prior run: what
+        it already found (so it doesn't repeat claims) and where it left off (so it
+        digs deeper). Keeps the agenda/ledger as the shared state, not the chat."""
+        agenda_lines = "\n".join(
+            f"  [{a['status']}] {a['id']}: {a['question']}"
+            + (f"  (follow-up of {a['parent']})" if a.get("parent") else "")
+            for a in self.agenda) or "  (none)"
+        claim_lines = "\n".join(
+            f"  {c['id']} [{c.get('kind', 'observation')}] {c['statement']}"
+            for c in self.ledger) or "  (none)"
+        return (
+            "You are RESUMING your own earlier investigation of this dataset — keep "
+            "digging DEEPER, don't restart.\n\n"
+            f"Agenda so far (statuses):\n{agenda_lines}\n\n"
+            f"Claims you already recorded — do NOT repeat these; build beyond them:\n{claim_lines}\n\n"
+            "Work any pending/interrupted items, then add_followup on the most promising "
+            "or surprising leads and pursue them (a cluster → its driver taxa → are they "
+            "contamination?). Record new claims for what you find. Reply DONE only when "
+            "you judge the investigation has gone deep enough.")
+
+    async def explore(self, resume: bool = False) -> bool:
         """Run the agenda-driven tool-calling loop. Returns True only when the
         agenda (including follow-ups) was actually worked through; on a step-cap
-        exit the in-progress item is marked ``interrupted`` (never faked done)."""
-        messages = [
-            {"role": "system", "content": EXPLORE_SYSTEM},
-            {"role": "user", "content": "Propose your agenda of microbial-ecology tests, "
-             "then work through it, recursing where it gets interesting."}]
+        exit the in-progress item is marked ``interrupted`` (never faked done).
+
+        With ``resume=True`` this CONTINUES a run reconstructed from a snapshot:
+        interrupted items are reactivated and the model is re-briefed with what it
+        already found so it goes deeper instead of proposing a fresh agenda."""
+        if resume:
+            for a in self.agenda:            # reactivate work parked at the last stop
+                if a["status"] == "interrupted":
+                    a["status"] = "pending"
+            messages = [
+                {"role": "system", "content": EXPLORE_SYSTEM},
+                {"role": "user", "content": self._resume_briefing()}]
+        else:
+            messages = [
+                {"role": "system", "content": EXPLORE_SYSTEM},
+                {"role": "user", "content": "Propose your agenda of microbial-ecology tests, "
+                 "then work through it, recursing where it gets interesting."}]
         for step in range(self.max_steps):
             r = await self.llm.chat(messages, model=self.explore_model, tools=TOOLS,
                                     tool_choice="auto", temperature=0.25, max_tokens=2500)

--- a/portal/app/autoresearch.py
+++ b/portal/app/autoresearch.py
@@ -19,8 +19,9 @@ but respects the HARD CONSTRAINTS of #29:
   * the LLM is acquired only through ``resolve_llm`` (no hardcoded endpoint).
 
 Routes:
-  * ``POST /autoresearch/{slug}/run-stream`` — SSE run + persistence + optional PR.
-  * ``GET  /autoresearch/{slug}/provenance`` — the provenance DAG viewer.
+  * ``POST /autoresearch/{slug}/run-stream`` — SSE run (``?resume=true`` to keep
+    digging from the prior snapshot) + persistence + optional PR.
+  * ``GET  /autoresearch/{slug}/findings`` — the claim/evidence findings viewer.
 """
 import asyncio
 import json
@@ -125,6 +126,7 @@ async def _build_data_source(slug: str, study: dict):
 @router.post("/{slug}/run-stream")
 async def run_autoresearch_stream(
     slug: str,
+    resume: bool = False,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_user),
 ):
@@ -136,7 +138,12 @@ async def run_autoresearch_stream(
     on a background task while forwarding tool-call / verification events over SSE.
     On completion the resolved snapshot is persisted to
     ``interview_data['_autoresearch']`` in a fresh DB session and (optionally) the
-    Results prose is committed to the paper repo's ``.omc/`` via a PR."""
+    Results prose is committed to the paper repo's ``.omc/`` via a PR.
+
+    With ``resume=true`` ("keep digging") the prior persisted snapshot is
+    reconstructed and the agent CONTINUES from where it stopped — running another
+    ``max_steps`` batch that appends to the same ledger. The user stops simply by
+    not asking for another batch."""
     if not settings.autoresearch_enabled:
         raise HTTPException(status_code=403, detail="Autoresearch is not enabled.")
 
@@ -173,6 +180,13 @@ async def run_autoresearch_stream(
 
     llm = await _get_llm_config(user.id)
     user_id = user.id
+    # Per-user depth (blank → site default). See /settings/autoresearch.
+    max_steps = user.autoresearch_max_steps or settings.autoresearch_max_steps
+
+    # "Keep digging": reconstruct from the prior snapshot and continue. Falls back
+    # to a fresh run if resume was asked but nothing has been persisted yet.
+    prior_snapshot = sub_interview.get("_autoresearch") if resume else None
+    resuming = bool(prior_snapshot)
 
     result_holder: dict = {}
 
@@ -218,18 +232,24 @@ async def run_autoresearch_stream(
                     AsyncOpenAI(base_url=llm["base_url"], api_key=llm["api_key"]),
                     model=llm["model"])
 
-                ar = Autoresearcher(
-                    data, llm_client, executor,
+                ar_kwargs = dict(
                     explore_model=settings.role_model("explore", llm["model"]),
                     verify_model=settings.role_model("verify", llm["model"]),
-                    max_steps=settings.autoresearch_max_steps,
+                    max_steps=max_steps,
                     max_followups=settings.autoresearch_max_followups,
                     reconcile=settings.autoresearch_reconcile_enabled,
                     on_progress=on_progress)
+                if resuming:
+                    await progress_queue.put({"event": "session",
+                                              "detail": f"resuming from {len(prior_snapshot.get('claims', []))} prior claims"})
+                    ar = Autoresearcher.from_snapshot(
+                        prior_snapshot, data, llm_client, executor, **ar_kwargs)
+                else:
+                    ar = Autoresearcher(data, llm_client, executor, **ar_kwargs)
 
                 # 4. Explore (time-budgeted) → verify → write prose → snapshot.
                 completed = await asyncio.wait_for(
-                    ar.explore(), timeout=settings.autoresearch_time_budget_s)
+                    ar.explore(resume=resuming), timeout=settings.autoresearch_time_budget_s)
                 await progress_queue.put({"event": "verify",
                                           "detail": "re-executing claims for verification"})
                 await ar.verify()
@@ -296,26 +316,26 @@ async def run_autoresearch_stream(
 
             complete = {
                 "event": "complete",
-                "detail": "Autoresearch complete — view the provenance ledger",
-                "ledger_url": f"/autoresearch/{sub_slug}/provenance",
+                "detail": "Autoresearch complete — view the findings",
+                "ledger_url": f"/autoresearch/{sub_slug}/findings",
             }
             yield f"data: {json.dumps(complete)}\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
-# ── provenance viewer ─────────────────────────────────────────────────────────
-@router.get("/{slug}/provenance")
-async def provenance_viewer(
+# ── findings viewer ───────────────────────────────────────────────────────────
+@router.get("/{slug}/findings")
+async def findings_viewer(
     slug: str,
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
-    """Render the provenance DAG viewer for a completed autoresearch run.
+    """Render the findings viewer (the claim/evidence DAG) for an autoresearch run.
 
     Mirrors ``main.manuscript_preview``: owner-scoped load, redirect to the
     submission page when no run exists. The persisted snapshot is already fully
-    resolved (``snapshot(resolve=True)``), so ``provenance.html`` is pure-render —
+    resolved (``snapshot(resolve=True)``), so ``findings.html`` is pure-render —
     it consumes ``data_json`` and imports nothing from the bench / ``ai``."""
     user = await get_current_user(request, db)
     if not user:
@@ -338,7 +358,7 @@ async def provenance_viewer(
         return RedirectResponse(f"/submissions/{slug}", status_code=303)
 
     return templates.TemplateResponse(
-        "provenance.html",
+        "findings.html",
         {
             "request": request,
             "user": user,

--- a/portal/app/database.py
+++ b/portal/app/database.py
@@ -62,6 +62,9 @@ class User(Base):
     # NULL means "not chosen yet"; resolution falls back personal → admin → local.
     llm_backend = Column(String(20))
     llm_model = Column(String(255))  # model for the chosen backend
+    # Per-user autoresearch depth: the agent tool-call budget per run/continue
+    # batch. NULL means "use the site default" (settings.autoresearch_max_steps).
+    autoresearch_max_steps = Column(Integer)
     created_at = Column(DateTime, default=datetime.utcnow)
     last_login = Column(DateTime, default=datetime.utcnow)
 
@@ -218,6 +221,13 @@ async def init_db():
         except Exception:
             await conn.execute(text("ALTER TABLE users ADD COLUMN llm_model VARCHAR(255)"))
             logging.getLogger(__name__).info("Added llm_model column to users")
+
+        # Migration: per-user autoresearch depth (agent tool-call budget per batch)
+        try:
+            await conn.execute(text("SELECT autoresearch_max_steps FROM users LIMIT 1"))
+        except Exception:
+            await conn.execute(text("ALTER TABLE users ADD COLUMN autoresearch_max_steps INTEGER"))
+            logging.getLogger(__name__).info("Added autoresearch_max_steps column to users")
 
         # Migration: make bioproject_accession nullable (SQLite can't ALTER constraints,
         # so recreate the table if the column is NOT NULL)

--- a/portal/app/openrouter.py
+++ b/portal/app/openrouter.py
@@ -85,8 +85,33 @@ async def settings_page(
             "admin_key_available": bool(admin_cfg),
             "personal_recommended": OPENROUTER_DEFAULT_MODEL,
             "active_label": active["label"],
+            # Autoresearch depth: user's per-run budget (blank → the site default).
+            "autoresearch_enabled": settings.autoresearch_enabled,
+            "autoresearch_max_steps": user.autoresearch_max_steps,
+            "autoresearch_max_steps_default": settings.autoresearch_max_steps,
         },
     )
+
+
+@router.post("/settings/autoresearch")
+async def set_autoresearch(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Save the user's autoresearch depth (agent tool-call budget per run/continue
+    batch). Blank/0 clears it → the site default applies. Bounded to a sane range."""
+    form = await request.form()
+    raw = (form.get("max_steps") or "").strip()
+    if not raw:
+        user.autoresearch_max_steps = None
+    else:
+        try:
+            user.autoresearch_max_steps = max(4, min(200, int(raw)))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="max_steps must be a number")
+    await db.commit()
+    return RedirectResponse("/settings?saved=1", status_code=303)
 
 
 @router.post("/settings/llm")

--- a/portal/templates/_autoresearch_trigger.html
+++ b/portal/templates/_autoresearch_trigger.html
@@ -16,19 +16,24 @@
   `settings.autoresearch_enabled` in config.py (Task E).
 
   Backend contract (Task C):
-    POST /autoresearch/{slug}/run-stream   — SSE: session/agenda/run_analysis/
-                                             record_claim/verify/reconcile/complete/error
-    GET  /autoresearch/{slug}/provenance   — the claim-provenance viewer
+    POST /autoresearch/{slug}/run-stream          — SSE: session/agenda/run_analysis/
+                                                    record_claim/verify/reconcile/complete/error
+    POST /autoresearch/{slug}/run-stream?resume=true — "keep digging" from prior snapshot
+    GET  /autoresearch/{slug}/findings            — the claim/evidence findings viewer
 #}
 {% if settings and settings.autoresearch_enabled %}
 {% set has_autoresearch = submission.interview_data and submission.interview_data.get('_autoresearch') %}
 <div class="wf-step-actions" style="margin-top: 0.5rem;">
     <button class="btn btn-secondary" onclick="runAutoresearch()"
         {% if not has_pipeline_results %}title="Available once pipeline results are ready" disabled{% endif %}>
-        {% if has_autoresearch %}Re-run Autoresearch{% else %}Run Autoresearch{% endif %}
+        {% if has_autoresearch %}Re-run from scratch{% else %}Run Autoresearch{% endif %}
     </button>
     {% if has_autoresearch %}
-    <a href="/autoresearch/{{ submission.slug }}/provenance" class="btn btn-secondary">View Provenance</a>
+    <button class="btn btn-primary" onclick="runAutoresearch(true)"
+        title="Continue the investigation from where it left off and dig deeper">
+        Keep digging
+    </button>
+    <a href="/autoresearch/{{ submission.slug }}/findings" class="btn btn-secondary">View Findings</a>
     {% endif %}
 </div>
 
@@ -40,12 +45,13 @@
 </div>
 
 <script>
-async function runAutoresearch() {
+async function runAutoresearch(resume = false) {
     const progressDiv = document.getElementById('ar-progress');
     const logDiv = document.getElementById('ar-log');
     progressDiv.style.display = '';
     logDiv.innerHTML = '';
-    if (typeof showPersistentStatus === 'function') showPersistentStatus('Running autoresearch...');
+    if (typeof showPersistentStatus === 'function')
+        showPersistentStatus(resume ? 'Digging deeper...' : 'Running autoresearch...');
 
     function scrollLog() {
         const term = document.getElementById('ar-terminal');
@@ -74,10 +80,11 @@ async function runAutoresearch() {
         }
     }
 
-    appendLog('Starting claim-grounded autoresearch...');
+    appendLog(resume ? 'Resuming — digging deeper from where it left off...'
+                     : 'Starting claim-grounded autoresearch...');
 
     try {
-        const resp = await fetch(`/autoresearch/${subId}/run-stream`, {
+        const resp = await fetch(`/autoresearch/${subId}/run-stream${resume ? '?resume=true' : ''}`, {
             method: 'POST', credentials: 'same-origin',
         });
 
@@ -135,7 +142,7 @@ async function runAutoresearch() {
                         break;
                     case 'complete':
                         appendLog(d || 'Autoresearch complete.', '#22c55e');
-                        if (typeof showStatus === 'function') showStatus('Autoresearch complete! Opening provenance...');
+                        if (typeof showStatus === 'function') showStatus('Autoresearch complete! Opening findings...');
                         if (msg.ledger_url) {
                             setTimeout(() => window.location.href = msg.ledger_url, 1500);
                         } else {

--- a/portal/templates/findings.html
+++ b/portal/templates/findings.html
@@ -16,7 +16,7 @@
   Self-contained: no external assets beyond what base.html already loads.
 #}
 
-{% block title %}Claim Provenance — {{ submission.title or submission.slug if submission else 'Autoresearch' }} - OMC{% endblock %}
+{% block title %}Findings — {{ submission.title or submission.slug if submission else 'Autoresearch' }} - OMC{% endblock %}
 
 {% block head %}
 <style>
@@ -147,8 +147,8 @@
       <ul class="claims" id="list"></ul>
     </section>
     <aside>
-      <p class="col-h">Provenance</p>
-      <div class="detail" id="detail"><p class="empty">Select a claim to inspect its provenance.</p></div>
+      <p class="col-h">Evidence</p>
+      <div class="detail" id="detail"><p class="empty">Select a claim to inspect its evidence.</p></div>
     </aside>
   </div>
 

--- a/portal/templates/settings.html
+++ b/portal/templates/settings.html
@@ -139,6 +139,26 @@
         <p style="color: var(--color-success); margin-top: 0.75rem;">Saved. New work will use this model.</p>
         {% endif %}
     </div>
+
+    {% if autoresearch_enabled %}
+    <div class="submission-meta" style="max-width: 820px; margin-top: 1.5rem;">
+        <h3 style="margin-bottom: 0.5rem;">Autoresearch depth</h3>
+        <p style="color: var(--color-text-muted); font-size: 0.9em;">
+            How many analysis steps the agent runs per batch when it explores your data
+            (and each time you press <strong>Keep digging</strong>). Higher means it can
+            investigate more before pausing, but takes longer. Leave blank to use the
+            site default (<strong>{{ autoresearch_max_steps_default }}</strong>).
+        </p>
+        <form action="/settings/autoresearch" method="POST" style="margin-top: 1rem;">
+            <label for="ar-max-steps" style="font-size: 0.9em;">Steps per batch</label>
+            <input type="number" id="ar-max-steps" name="max_steps" min="4" max="200"
+                   value="{{ autoresearch_max_steps if autoresearch_max_steps else '' }}"
+                   placeholder="{{ autoresearch_max_steps_default }}"
+                   style="width: 8rem; margin-left: 0.5rem;">
+            <button type="submit" class="btn btn-primary" style="margin-left: 0.5rem;">Save</button>
+        </form>
+    </div>
+    {% endif %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Three changes from live-testing feedback on the dashboard run:

## 1. Keep digging (continue where it left off)
The core already parked unfinished agenda items as `interrupted` rather than faking completion, so resuming is clean:
- `explore(resume=True)` reactivates interrupted items and re-briefs the model with the agenda + claims it already recorded, so it digs **deeper** instead of restarting.
- `POST /run-stream?resume=true` rebuilds from the prior persisted snapshot (`from_snapshot`) and appends to the same ledger.
- UI: a **Keep digging** button (primary) next to Re-run/View. No Stop button — per your call, stopping just means not clicking Keep digging again.

## 2. Rename provenance → findings
The view is the accumulating findings, not a lineage trace. `/provenance`→`/findings`, `provenance.html`→`findings.html`, "View Provenance"→"View Findings", evidence panel relabeled. (Body prose still uses "provenance" where it means machine-checkable lineage.)

## 3. Per-user autoresearch depth
`users.autoresearch_max_steps` column (+ auto-migration), a control in `/settings` (blank → site default, left at 24), wired into the run so the user's setting drives depth.

Offline gate green (`--reverify` 18/18); resume briefing + interrupted-reset unit-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)