### PR TITLE
autoresearch: per-artifact model attribution

### DIFF
--- a/ai/autoresearch.py
+++ b/ai/autoresearch.py
@@ -638,6 +638,7 @@ class Autoresearcher:
         self.ledger: list[dict] = []              # claim dicts
         self.agenda: list[dict] = []              # {id, question, rationale, status, parent}
         self.results_prose: str | None = None     # last write_results() output (for snapshot)
+        self.results_prose_by: str | None = None  # model that wrote the prose
 
     # -- progress ---------------------------------------------------------------
     async def _emit(self, event: str, detail: Any) -> None:
@@ -700,14 +701,16 @@ class Autoresearcher:
                 return {"ok": False, "error": res}
             cid = f"c{len(self.computations) + 1}"
             self.computations[cid] = {"label": args.get("label", cid),
-                                      "code": args.get("code", ""), "result": res}
+                                      "code": args.get("code", ""), "result": res,
+                                      "by": self.explore_model}  # model that wrote it
             return {"ok": True, "computation_id": cid, "result": res}
         if name == "record_claim":
             claim = {"id": f"k{len(self.ledger) + 1}", "statement": args.get("statement", ""),
                      "value": str(args.get("value", "")),
                      "antecedents": _norm_antecedents(args.get("antecedents")),
                      "kind": args.get("kind", "observation"),
-                     "investigation": self._current_investigation()}
+                     "investigation": self._current_investigation(),
+                     "by": self.explore_model}  # model that recorded this claim
             self.ledger.append(claim)
             return {"recorded": True, "claim_id": claim["id"], "n_claims": len(self.ledger)}
         return {"error": f"unknown tool {name}"}
@@ -868,9 +871,11 @@ class Autoresearcher:
             # the SAME re-executed evidence (labelled, so judgment-backed claims are visible).
             if c["verdict"] != "verified" and self.reconcile and have_evidence:
                 rec = await self._reconcile_claim(c, comp_cache)
+                rec["by"] = self.verify_model            # model that adjudicated
                 c["reconcile"] = rec
                 if rec["verdict"] == "supported":
                     c["verdict"], c["method"] = "verified", "reconciled"
+                    c["reconciled_by"] = self.verify_model
 
     # -- DAG --------------------------------------------------------------------
     def build_dag(self) -> dict:
@@ -899,16 +904,24 @@ class Autoresearcher:
             if content.strip():
                 break
         self.results_prose = content
+        self.results_prose_by = self.explore_model     # stamp the writer
         return content
 
     # -- run summary ------------------------------------------------------------
     def run_summary(self, completed: bool | None = None) -> dict:
-        """The ``run`` block (completed + investigation counts) for the snapshot/ledger."""
+        """The ``run`` block (completed + investigation counts + the roster of models
+        that contributed) for the snapshot/ledger. ``models`` is every distinct model
+        that recorded a claim, wrote a computation, reconciled, or wrote the prose —
+        so a run continued ("keep digging") by a different model attributes truthfully."""
         done = sum(a["status"] == "done" for a in self.agenda)
         if completed is None:
             completed = bool(self.agenda) and all(a["status"] == "done" for a in self.agenda)
+        models = {c.get("by") for c in self.ledger} | {c.get("reconciled_by") for c in self.ledger}
+        models |= {c.get("by") for c in self.computations.values()}
+        models.add(self.results_prose_by)
         return {"completed": completed, "investigations_done": done,
-                "investigations_total": len(self.agenda)}
+                "investigations_total": len(self.agenda),
+                "models": sorted(m for m in models if m)}
 
     # -- snapshot ---------------------------------------------------------------
     def snapshot(self, resolve: bool = True, completed: bool | None = None,
@@ -936,6 +949,9 @@ class Autoresearcher:
                 "id": c["id"], "statement": c["statement"], "value": c["value"],
                 "verdict": c.get("verdict", "unverifiable"), "kind": c.get("kind", "observation"),
                 "method": c.get("method"), "antecedents": c["antecedents"],
+                # Per-artifact attribution: the model that recorded the claim, and
+                # (when applicable) the model that reconciled it into "verified".
+                "by": c.get("by"), "reconciled_by": c.get("reconciled_by"),
             }
             if c.get("reconcile"):
                 entry["reconcile"] = c["reconcile"]
@@ -948,6 +964,7 @@ class Autoresearcher:
             "agenda": self.agenda,
             "dag": self.build_dag(),
             "results_prose": results_prose,
+            "results_prose_by": self.results_prose_by,
             "run": self.run_summary(completed),
         }
 

--- a/portal/app/autoresearch.py
+++ b/portal/app/autoresearch.py
@@ -282,9 +282,17 @@ async def run_autoresearch_stream(
             try:
                 interview_data = dict(sub_interview)
                 interview_data["_autoresearch"] = snapshot
-                # Provenance: name the backend/model that produced this run (#16 idiom).
+                # Provenance (#16 idiom). Per-artifact attribution lives on each claim/
+                # computation (snapshot .by / .reconciled_by); here we keep the LATEST
+                # run's label plus the accumulated ROSTER of every backend·model that has
+                # contributed — so "keep digging" with a different model never erases who
+                # produced the earlier claims.
                 interview_data["_autoresearch_model"] = llm.get("label")
                 interview_data["_autoresearch_backend"] = llm.get("backend")
+                roster = list(sub_interview.get("_autoresearch_models") or [])
+                if llm.get("label") and llm["label"] not in roster:
+                    roster.append(llm["label"])
+                interview_data["_autoresearch_models"] = roster
 
                 async with async_session() as save_db:
                     save_result = await save_db.execute(
@@ -371,5 +379,7 @@ async def findings_viewer(
                           .replace("&", "\\u0026").replace("\u2028", "\\u2028")
                           .replace("\u2029", "\\u2029")),
             "model_label": interview_data.get("_autoresearch_model"),
+            "model_roster": interview_data.get("_autoresearch_models") or (
+                [interview_data["_autoresearch_model"]] if interview_data.get("_autoresearch_model") else []),
         },
     )

--- a/portal/templates/findings.html
+++ b/portal/templates/findings.html
@@ -170,6 +170,9 @@ const RUN = DATA.run || {};
 const esc = s => String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
 const fmt = v => (typeof v === 'string' ? v : JSON.stringify(v));
 const trunc = (v, n) => { const s = (v == null ? '' : fmt(v)); return s.length > n ? s.slice(0, n) : s; };
+// Compact model id for a per-artifact attribution stamp: drop the provider prefix
+// ("anthropic/claude-sonnet-5" → "claude-sonnet-5"), keep it short but identifying.
+const shortModel = m => !m ? '' : String(m).split('/').pop();
 
 // Preliminary banner when exploration stopped before completing the agenda.
 if (RUN && RUN.completed === false) {
@@ -197,6 +200,14 @@ document.getElementById('stats').innerHTML = [
   ['computations', S.computations, '']
 ].map(([l,n,c]) => `<div class="stat ${c}"><div class="n">${n}</div><div class="l">${l}</div></div>`).join('');
 
+// Model roster: every model that contributed to this run (claims may span several
+// after "keep digging"). Per-claim attribution is on each claim below.
+const MODELS = (RUN.models || []).map(shortModel).filter(Boolean);
+if (MODELS.length) {
+  const sub = document.getElementById('study');
+  if (sub) sub.innerHTML += ` · <span title="models that produced these findings">by ${MODELS.map(esc).join(', ')}</span>`;
+}
+
 const KIND = {quality_caveat:['caveat','caveat'], anomaly:['anomaly','anomaly'], pattern:['pattern','pattern']};
 
 const list = document.getElementById('list');
@@ -213,8 +224,12 @@ CLAIMS.forEach((c,i) => {
     ? `<span class="chip">${nd.map(x=>chipMap[x]||x).join(' · ')}</span>` : '';
   const k = KIND[c.kind];
   const kindChip = k ? `<span class="kind ${k[1]}">${k[0]}</span>` : '';
+  // Only show a per-claim model chip when the run spans >1 model (otherwise the
+  // roster in the header already says it, and the chip is just noise).
+  const byChip = (MODELS.length > 1 && c.by)
+    ? `<span class="chip" title="recorded by ${esc(c.by)}">${esc(shortModel(c.by))}</span>` : '';
   b.innerHTML = `<span class="dot ${c.verdict}"></span><span class="txt">`
-    + `<span class="cid">${esc(c.id)}</span>` + kindChip + chip
+    + `<span class="cid">${esc(c.id)}</span>` + kindChip + chip + byChip
     + `<br>${esc(c.statement)}</span>`;
   b.onclick = () => select(i);
   list.appendChild(b);
@@ -269,6 +284,8 @@ function select(i){
     + (dk ? `<span class="kind ${dk[1]}" style="margin-left:8px">${dk[0]}</span>` : '')
     + `<h2>${esc(c.statement)}</h2>`
     + `<div class="kv"><span class="k">value</span><span class="v">${esc(c.value)}</span></div>`
+    + (c.by ? `<div class="kv"><span class="k">recorded by</span><span class="v">${esc(shortModel(c.by))}</span></div>` : '')
+    + (c.reconciled_by ? `<div class="kv"><span class="k">reconciled by</span><span class="v">${esc(shortModel(c.reconciled_by))}</span></div>` : '')
     + `<div class="reverify">${reverify}</div>`
     + (c.reconcile ? `<div class="reconcile"><b>Model adjudication:</b> ${esc((c.reconcile.reasoning||'').replace(/^VERDICT:[^\n]*\n?/i,''))}</div>` : '')
     + `<p class="prov-h">Antecedents (${antCount})</p>${ants}`;


### PR DESCRIPTION
Per your ask — every model that does something leaves its stamp. Attribution was run-level only (`_autoresearch_model`) and **overwritten** on resume, so a 'keep digging' batch by a different model would falsely credit everything to the last one.

Now every artifact carries its producer:
- each **claim** → `by` (explore model that recorded it)
- each **computation** → `by`
- a **reconciled** verdict → `reconciled_by` (verify model that adjudicated)
- the **Results prose** → `results_prose_by`
- `run_summary` gains a **`models`** roster (every distinct contributor)

Route accumulates `_autoresearch_models` across runs instead of overwriting. Findings viewer shows the roster in the header, a per-claim model chip when a run spans >1 model, and recorded-by / reconciled-by in the detail panel.

Offline `--reverify` 18/18 (old ledgers without `.by` still verify); stamps + roster unit-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)